### PR TITLE
Convenient Inventory 1.2.0

### DIFF
--- a/ConvenientInventory/ConvenientInventory.sln
+++ b/ConvenientInventory/ConvenientInventory.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.31613.86
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConvenientInventory", "ConvenientInventory\ConvenientInventory.csproj", "{287A38BF-C277-4F67-8D15-C7CBE4231BB6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConvenientInventory", "ConvenientInventory\ConvenientInventory.csproj", "{287A38BF-C277-4F67-8D15-C7CBE4231BB6}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/ConvenientInventory/ConvenientInventory/Compatibility/IGenericModConfigMenuApi.cs
+++ b/ConvenientInventory/ConvenientInventory/Compatibility/IGenericModConfigMenuApi.cs
@@ -6,48 +6,48 @@ using StardewModdingAPI.Utilities;
 
 namespace GenericModConfigMenu
 {
-	public interface IGenericModConfigMenuApi
-	{
-		void RegisterModConfig(IManifest mod, Action revertToDefault, Action saveToFile);
-		void UnregisterModConfig(IManifest mod);
+    public interface IGenericModConfigMenuApi
+    {
+        void RegisterModConfig(IManifest mod, Action revertToDefault, Action saveToFile);
+        void UnregisterModConfig(IManifest mod);
 
-		void SetDefaultIngameOptinValue(IManifest mod, bool optedIn);
+        void SetDefaultIngameOptinValue(IManifest mod, bool optedIn);
 
-		void StartNewPage(IManifest mod, string pageName);
-		void OverridePageDisplayName(IManifest mod, string pageName, string displayName);
+        void StartNewPage(IManifest mod, string pageName);
+        void OverridePageDisplayName(IManifest mod, string pageName, string displayName);
 
-		void RegisterLabel(IManifest mod, string labelName, string labelDesc);
-		void RegisterPageLabel(IManifest mod, string labelName, string labelDesc, string newPage);
-		void RegisterParagraph(IManifest mod, string paragraph);
-		void RegisterImage(IManifest mod, string texPath, Rectangle? texRect = null, int scale = 4);
+        void RegisterLabel(IManifest mod, string labelName, string labelDesc);
+        void RegisterPageLabel(IManifest mod, string labelName, string labelDesc, string newPage);
+        void RegisterParagraph(IManifest mod, string paragraph);
+        void RegisterImage(IManifest mod, string texPath, Rectangle? texRect = null, int scale = 4);
 
-		void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<bool> optionGet, Action<bool> optionSet);
-		void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet);
-		void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet);
-		void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet);
-		void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<SButton> optionGet, Action<SButton> optionSet);
-		void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<KeybindList> optionGet, Action<KeybindList> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<bool> optionGet, Action<bool> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<SButton> optionGet, Action<SButton> optionSet);
+        void RegisterSimpleOption(IManifest mod, string optionName, string optionDesc, Func<KeybindList> optionGet, Action<KeybindList> optionSet);
 
-		void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet, int min, int max);
-		void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet, float min, float max);
-		void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet, int min, int max, int interval);
-		void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet, float min, float max, float interval);
+        void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet, int min, int max);
+        void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet, float min, float max);
+        void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<int> optionGet, Action<int> optionSet, int min, int max, int interval);
+        void RegisterClampedOption(IManifest mod, string optionName, string optionDesc, Func<float> optionGet, Action<float> optionSet, float min, float max, float interval);
 
-		void RegisterChoiceOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet, string[] choices);
+        void RegisterChoiceOption(IManifest mod, string optionName, string optionDesc, Func<string> optionGet, Action<string> optionSet, string[] choices);
 
-		void RegisterComplexOption(IManifest mod, string optionName, string optionDesc, Func<Vector2, object, object> widgetUpdate, Func<SpriteBatch, Vector2, object, object> widgetDraw, Action<object> onSave);
+        void RegisterComplexOption(IManifest mod, string optionName, string optionDesc, Func<Vector2, object, object> widgetUpdate, Func<SpriteBatch, Vector2, object, object> widgetDraw, Action<object> onSave);
 
-		void SubscribeToChange(IManifest mod, Action<string, bool> changeHandler);
-		void SubscribeToChange(IManifest mod, Action<string, int> changeHandler);
-		void SubscribeToChange(IManifest mod, Action<string, float> changeHandler);
-		void SubscribeToChange(IManifest mod, Action<string, string> changeHandler);
+        void SubscribeToChange(IManifest mod, Action<string, bool> changeHandler);
+        void SubscribeToChange(IManifest mod, Action<string, int> changeHandler);
+        void SubscribeToChange(IManifest mod, Action<string, float> changeHandler);
+        void SubscribeToChange(IManifest mod, Action<string, string> changeHandler);
 
-		void OpenModMenu(IManifest mod);
+        void OpenModMenu(IManifest mod);
 
-		/// <summary>Get the currently-displayed mod config menu, if any.</summary>
-		/// <param name="mod">The manifest of the mod whose config menu is being shown, or <c>null</c> if not applicable.</param>
-		/// <param name="page">The page ID being shown for the current config menu, or <c>null</c> if not applicable. This may be <c>null</c> even if a mod config menu is shown (e.g. because the mod doesn't have pages).</param>
-		/// <returns>Returns whether a mod config menu is being shown.</returns>
-		bool TryGetCurrentMenu(out IManifest mod, out string page);
-	}
+        /// <summary>Get the currently-displayed mod config menu, if any.</summary>
+        /// <param name="mod">The manifest of the mod whose config menu is being shown, or <c>null</c> if not applicable.</param>
+        /// <param name="page">The page ID being shown for the current config menu, or <c>null</c> if not applicable. This may be <c>null</c> even if a mod config menu is shown (e.g. because the mod doesn't have pages).</param>
+        /// <returns>Returns whether a mod config menu is being shown.</returns>
+        bool TryGetCurrentMenu(out IManifest mod, out string page);
+    }
 }

--- a/ConvenientInventory/ConvenientInventory/Compatibility/ModInitializer.cs
+++ b/ConvenientInventory/ConvenientInventory/Compatibility/ModInitializer.cs
@@ -1,0 +1,154 @@
+﻿using GenericModConfigMenu;
+using Microsoft.Xna.Framework.Graphics;
+using StardewModdingAPI;
+
+namespace ConvenientInventory.Compatibility
+{
+    public class ModInitializer
+    {
+		private readonly IManifest _modManifest;
+		private readonly IModHelper _helper;
+
+		public ModInitializer(IManifest modManifest, IModHelper helper)
+        {
+			_modManifest = modManifest;
+			_helper = helper;
+        }
+
+        public void Initialize(IGenericModConfigMenuApi api, ModConfig config)
+        {
+			api.RegisterModConfig(
+				mod: _modManifest,
+				revertToDefault: () => config = new ModConfig(),
+				saveToFile: () => _helper.WriteConfig(config)
+			);
+
+			api.SetDefaultIngameOptinValue(_modManifest, true);
+
+			api.RegisterLabel(
+				mod: _modManifest,
+				labelName: "Quick Stack To Nearby Chests",
+				labelDesc: null
+			);
+
+			api.RegisterSimpleOption(
+				mod: _modManifest,
+				optionName: "Enable Quick stack?",
+				optionDesc: "If enabled, adds a \"Quick Stack To Nearby Chests\" button to your inventory menu. Pressing this button will stack items from your inventory to any nearby chests which contain that item.",
+				optionGet: () => config.IsEnableQuickStack,
+				optionSet: value => config.IsEnableQuickStack = value
+			);
+
+			api.RegisterClampedOption(
+				mod: _modManifest,
+				optionName: "Range",
+				optionDesc: "How many tiles away from the player to search for nearby chests.",
+				optionGet: () => config.QuickStackRange,
+				optionSet: value => config.QuickStackRange = value,
+				min: 0,
+				max: 10,
+				interval: 1
+			);
+
+			api.RegisterSimpleOption(
+				mod: _modManifest,
+				optionName: "Enable hotkey?",
+				optionDesc: "If enabled, pressing either of the quick stack hotkeys specified below will quick stack your items, even outside of your inventory menu.",
+				optionGet: () => config.IsEnableQuickStackHotkey,
+				optionSet: value => config.IsEnableQuickStackHotkey = value
+			);
+
+			api.RegisterSimpleOption(
+				mod: _modManifest,
+				optionName: "Keybind (keyboard)",
+				optionDesc: "Press this key to quick stack your items.",
+				optionGet: () => config.QuickStackKeyboardHotkey,
+				optionSet: value => config.QuickStackKeyboardHotkey = value
+			);
+
+			api.RegisterSimpleOption(
+				mod: _modManifest,
+				optionName: "Keybind (controller)",
+				optionDesc: "Press this button to quick stack your items.",
+				optionGet: () => config.QuickStackControllerHotkey,
+				optionSet: value => config.QuickStackControllerHotkey = value
+			);
+
+			api.RegisterSimpleOption(
+				mod: _modManifest,
+				optionName: "Quick stack into buildings?",
+				optionDesc: "If enabled, nearby buildings with inventories (such as Mills or Junimo Huts) will also be checked when quick stacking.",
+				optionGet: () => config.IsQuickStackIntoBuildingsWithInventories,
+				optionSet: value => config.IsQuickStackIntoBuildingsWithInventories = value
+			);
+
+			api.RegisterSimpleOption(
+				mod: _modManifest,
+				optionName: "Quick stack overflow items?",
+				optionDesc: "If enabled, quick stack will place as many items as possible into chests which contain that item, rather than just a single stack.",
+				optionGet: () => config.IsQuickStackOverflowItems,
+				optionSet: value => config.IsQuickStackOverflowItems = value
+			);
+
+			api.RegisterSimpleOption(
+				mod: _modManifest,
+				optionName: "Show nearby chests in tooltip?",
+				optionDesc: "If enabled, hovering over the quick stack button will show a preview of all nearby chests, ordered by distance.",
+				optionGet: () => config.IsQuickStackTooltipDrawNearbyChests,
+				optionSet: value => config.IsQuickStackTooltipDrawNearbyChests = value
+			);
+
+			api.RegisterLabel(
+				mod: _modManifest,
+				labelName: "Favorite Items",
+				labelDesc: null
+			);
+
+			api.RegisterSimpleOption(
+				mod: _modManifest,
+				optionName: "Enable favorite items?",
+				optionDesc: "If enabled, items in your inventory can be favorited. Favorited items will be ignored when stacking into chests.",
+				optionGet: () => config.IsEnableFavoriteItems,
+				optionSet: value => config.IsEnableFavoriteItems = value
+			);
+
+			string[] highlightStyleDescriptions =
+				{
+					"0: Gold dashed",
+					"1: Clean gold dashed",
+					"2: Thick gold border",
+					"3: Textured gold inset border",
+					"4: Gold inset border",
+					"5: Dark dashed"
+				};
+			api.RegisterChoiceOption(
+				mod: _modManifest,
+				optionName: "Highlight style",
+				optionDesc: "Choose your preferred texture style for highlighting favorited items in your inventory.",
+				optionGet: () => highlightStyleDescriptions[config.FavoriteItemsHighlightTextureChoice],
+				optionSet: value =>
+					{
+						config.FavoriteItemsHighlightTextureChoice = int.Parse(value.Substring(0, 1));
+						ConvenientInventory.FavoriteItemsHighlightTexture = _helper.Content.Load<Texture2D>($@"assets\favoriteHighlight_{value[0]}.png");
+					},
+				choices: highlightStyleDescriptions
+			);
+
+			api.RegisterSimpleOption(
+				mod: _modManifest,
+				optionName: "Keybind (keyboard)",
+				optionDesc: "Hold this key when selecting an item to favorite it.",
+				optionGet: () => config.FavoriteItemsKeyboardHotkey,
+				optionSet: value => config.FavoriteItemsKeyboardHotkey = value
+			);
+
+			api.RegisterSimpleOption(
+				mod: _modManifest,
+				optionName: "Keybind (controller)",
+				optionDesc: "Hold this button when selecting an item to favorite it.",
+				optionGet: () => config.FavoriteItemsControllerHotkey,
+				optionSet: value => config.FavoriteItemsControllerHotkey = value
+			);
+		}
+    }
+}

--- a/ConvenientInventory/ConvenientInventory/Compatibility/ModInitializer.cs
+++ b/ConvenientInventory/ConvenientInventory/Compatibility/ModInitializer.cs
@@ -6,153 +6,153 @@ namespace ConvenientInventory.Compatibility
 {
     public class ModInitializer
     {
-		private readonly IManifest _modManifest;
-		private readonly IModHelper _helper;
+        private readonly IManifest _modManifest;
+        private readonly IModHelper _helper;
 
-		public ModInitializer(IManifest modManifest, IModHelper helper)
+        public ModInitializer(IManifest modManifest, IModHelper helper)
         {
-			_modManifest = modManifest;
-			_helper = helper;
+            _modManifest = modManifest;
+            _helper = helper;
         }
 
         public void Initialize(IGenericModConfigMenuApi api, ModConfig config)
         {
-			api.RegisterModConfig(
-				mod: _modManifest,
-				revertToDefault: () =>
-				{
-					config = new ModConfig();
-					ModEntry.Config = config;
-				},
-				saveToFile: () => _helper.WriteConfig(config)
-			);
+            api.RegisterModConfig(
+                mod: _modManifest,
+                revertToDefault: () =>
+                {
+                    config = new ModConfig();
+                    ModEntry.Config = config;
+                },
+                saveToFile: () => _helper.WriteConfig(config)
+            );
 
-			api.SetDefaultIngameOptinValue(_modManifest, true);
+            api.SetDefaultIngameOptinValue(_modManifest, true);
 
-			api.RegisterLabel(
-				mod: _modManifest,
-				labelName: "Quick Stack To Nearby Chests",
-				labelDesc: null
-			);
+            api.RegisterLabel(
+                mod: _modManifest,
+                labelName: "Quick Stack To Nearby Chests",
+                labelDesc: null
+            );
 
-			api.RegisterSimpleOption(
-				mod: _modManifest,
-				optionName: "Enable Quick stack?",
-				optionDesc: "If enabled, adds a \"Quick Stack To Nearby Chests\" button to your inventory menu. Pressing this button will stack items from your inventory to any nearby chests which contain that item.",
-				optionGet: () => config.IsEnableQuickStack,
-				optionSet: value => config.IsEnableQuickStack = value
-			);
+            api.RegisterSimpleOption(
+                mod: _modManifest,
+                optionName: "Enable Quick stack?",
+                optionDesc: "If enabled, adds a \"Quick Stack To Nearby Chests\" button to your inventory menu. Pressing this button will stack items from your inventory to any nearby chests which contain that item.",
+                optionGet: () => config.IsEnableQuickStack,
+                optionSet: value => config.IsEnableQuickStack = value
+            );
 
-			api.RegisterClampedOption(
-				mod: _modManifest,
-				optionName: "Range",
-				optionDesc: "How many tiles away from the player to search for nearby chests.",
-				optionGet: () => config.QuickStackRange,
-				optionSet: value => config.QuickStackRange = value,
-				min: 0,
-				max: 10,
-				interval: 1
-			);
+            api.RegisterClampedOption(
+                mod: _modManifest,
+                optionName: "Range",
+                optionDesc: "How many tiles away from the player to search for nearby chests.",
+                optionGet: () => config.QuickStackRange,
+                optionSet: value => config.QuickStackRange = value,
+                min: 0,
+                max: 10,
+                interval: 1
+            );
 
-			api.RegisterSimpleOption(
-				mod: _modManifest,
-				optionName: "Enable hotkey?",
-				optionDesc: "If enabled, pressing either of the quick stack hotkeys specified below will quick stack your items, even outside of your inventory menu.",
-				optionGet: () => config.IsEnableQuickStackHotkey,
-				optionSet: value => config.IsEnableQuickStackHotkey = value
-			);
+            api.RegisterSimpleOption(
+                mod: _modManifest,
+                optionName: "Enable hotkey?",
+                optionDesc: "If enabled, pressing either of the quick stack hotkeys specified below will quick stack your items, even outside of your inventory menu.",
+                optionGet: () => config.IsEnableQuickStackHotkey,
+                optionSet: value => config.IsEnableQuickStackHotkey = value
+            );
 
-			api.RegisterSimpleOption(
-				mod: _modManifest,
-				optionName: "Keybind (keyboard)",
-				optionDesc: "Press this key to quick stack your items.",
-				optionGet: () => config.QuickStackKeyboardHotkey,
-				optionSet: value => config.QuickStackKeyboardHotkey = value
-			);
+            api.RegisterSimpleOption(
+                mod: _modManifest,
+                optionName: "Keybind (keyboard)",
+                optionDesc: "Press this key to quick stack your items.",
+                optionGet: () => config.QuickStackKeyboardHotkey,
+                optionSet: value => config.QuickStackKeyboardHotkey = value
+            );
 
-			api.RegisterSimpleOption(
-				mod: _modManifest,
-				optionName: "Keybind (controller)",
-				optionDesc: "Press this button to quick stack your items.",
-				optionGet: () => config.QuickStackControllerHotkey,
-				optionSet: value => config.QuickStackControllerHotkey = value
-			);
+            api.RegisterSimpleOption(
+                mod: _modManifest,
+                optionName: "Keybind (controller)",
+                optionDesc: "Press this button to quick stack your items.",
+                optionGet: () => config.QuickStackControllerHotkey,
+                optionSet: value => config.QuickStackControllerHotkey = value
+            );
 
-			api.RegisterSimpleOption(
-				mod: _modManifest,
-				optionName: "Quick stack into buildings?",
-				optionDesc: "If enabled, nearby buildings with inventories (such as Mills or Junimo Huts) will also be checked when quick stacking.",
-				optionGet: () => config.IsQuickStackIntoBuildingsWithInventories,
-				optionSet: value => config.IsQuickStackIntoBuildingsWithInventories = value
-			);
+            api.RegisterSimpleOption(
+                mod: _modManifest,
+                optionName: "Quick stack into buildings?",
+                optionDesc: "If enabled, nearby buildings with inventories (such as Mills or Junimo Huts) will also be checked when quick stacking.",
+                optionGet: () => config.IsQuickStackIntoBuildingsWithInventories,
+                optionSet: value => config.IsQuickStackIntoBuildingsWithInventories = value
+            );
 
-			api.RegisterSimpleOption(
-				mod: _modManifest,
-				optionName: "Quick stack overflow items?",
-				optionDesc: "If enabled, quick stack will place as many items as possible into chests which contain that item, rather than just a single stack.",
-				optionGet: () => config.IsQuickStackOverflowItems,
-				optionSet: value => config.IsQuickStackOverflowItems = value
-			);
+            api.RegisterSimpleOption(
+                mod: _modManifest,
+                optionName: "Quick stack overflow items?",
+                optionDesc: "If enabled, quick stack will place as many items as possible into chests which contain that item, rather than just a single stack.",
+                optionGet: () => config.IsQuickStackOverflowItems,
+                optionSet: value => config.IsQuickStackOverflowItems = value
+            );
 
-			api.RegisterSimpleOption(
-				mod: _modManifest,
-				optionName: "Show nearby chests in tooltip?",
-				optionDesc: "If enabled, hovering over the quick stack button will show a preview of all nearby chests, ordered by distance.",
-				optionGet: () => config.IsQuickStackTooltipDrawNearbyChests,
-				optionSet: value => config.IsQuickStackTooltipDrawNearbyChests = value
-			);
+            api.RegisterSimpleOption(
+                mod: _modManifest,
+                optionName: "Show nearby chests in tooltip?",
+                optionDesc: "If enabled, hovering over the quick stack button will show a preview of all nearby chests, ordered by distance.",
+                optionGet: () => config.IsQuickStackTooltipDrawNearbyChests,
+                optionSet: value => config.IsQuickStackTooltipDrawNearbyChests = value
+            );
 
-			api.RegisterLabel(
-				mod: _modManifest,
-				labelName: "Favorite Items",
-				labelDesc: null
-			);
+            api.RegisterLabel(
+                mod: _modManifest,
+                labelName: "Favorite Items",
+                labelDesc: null
+            );
 
-			api.RegisterSimpleOption(
-				mod: _modManifest,
-				optionName: "Enable favorite items?",
-				optionDesc: "If enabled, items in your inventory can be favorited. Favorited items will be ignored when stacking into chests.",
-				optionGet: () => config.IsEnableFavoriteItems,
-				optionSet: value => config.IsEnableFavoriteItems = value
-			);
+            api.RegisterSimpleOption(
+                mod: _modManifest,
+                optionName: "Enable favorite items?",
+                optionDesc: "If enabled, items in your inventory can be favorited. Favorited items will be ignored when stacking into chests.",
+                optionGet: () => config.IsEnableFavoriteItems,
+                optionSet: value => config.IsEnableFavoriteItems = value
+            );
 
-			string[] highlightStyleDescriptions =
-				{
-					"0: Gold dashed",
-					"1: Clean gold dashed",
-					"2: Thick gold border",
-					"3: Textured gold inset border",
-					"4: Gold inset border",
-					"5: Dark dashed"
-				};
-			api.RegisterChoiceOption(
-				mod: _modManifest,
-				optionName: "Highlight style",
-				optionDesc: "Choose your preferred texture style for highlighting favorited items in your inventory.",
-				optionGet: () => highlightStyleDescriptions[config.FavoriteItemsHighlightTextureChoice],
-				optionSet: value =>
-					{
-						config.FavoriteItemsHighlightTextureChoice = int.Parse(value.Substring(0, 1));
-						ConvenientInventory.FavoriteItemsHighlightTexture = _helper.Content.Load<Texture2D>($@"assets\favoriteHighlight_{value[0]}.png");
-					},
-				choices: highlightStyleDescriptions
-			);
+            string[] highlightStyleDescriptions =
+                {
+                    "0: Gold dashed",
+                    "1: Clean gold dashed",
+                    "2: Thick gold border",
+                    "3: Textured gold inset border",
+                    "4: Gold inset border",
+                    "5: Dark dashed"
+                };
+            api.RegisterChoiceOption(
+                mod: _modManifest,
+                optionName: "Highlight style",
+                optionDesc: "Choose your preferred texture style for highlighting favorited items in your inventory.",
+                optionGet: () => highlightStyleDescriptions[config.FavoriteItemsHighlightTextureChoice],
+                optionSet: value =>
+                    {
+                        config.FavoriteItemsHighlightTextureChoice = int.Parse(value.Substring(0, 1));
+                        ConvenientInventory.FavoriteItemsHighlightTexture = _helper.Content.Load<Texture2D>($@"assets\favoriteHighlight_{value[0]}.png");
+                    },
+                choices: highlightStyleDescriptions
+            );
 
-			api.RegisterSimpleOption(
-				mod: _modManifest,
-				optionName: "Keybind (keyboard)",
-				optionDesc: "Hold this key when selecting an item to favorite it.",
-				optionGet: () => config.FavoriteItemsKeyboardHotkey,
-				optionSet: value => config.FavoriteItemsKeyboardHotkey = value
-			);
+            api.RegisterSimpleOption(
+                mod: _modManifest,
+                optionName: "Keybind (keyboard)",
+                optionDesc: "Hold this key when selecting an item to favorite it.",
+                optionGet: () => config.FavoriteItemsKeyboardHotkey,
+                optionSet: value => config.FavoriteItemsKeyboardHotkey = value
+            );
 
-			api.RegisterSimpleOption(
-				mod: _modManifest,
-				optionName: "Keybind (controller)",
-				optionDesc: "Hold this button when selecting an item to favorite it.",
-				optionGet: () => config.FavoriteItemsControllerHotkey,
-				optionSet: value => config.FavoriteItemsControllerHotkey = value
-			);
-		}
+            api.RegisterSimpleOption(
+                mod: _modManifest,
+                optionName: "Keybind (controller)",
+                optionDesc: "Hold this button when selecting an item to favorite it.",
+                optionGet: () => config.FavoriteItemsControllerHotkey,
+                optionSet: value => config.FavoriteItemsControllerHotkey = value
+            );
+        }
     }
 }

--- a/ConvenientInventory/ConvenientInventory/Compatibility/ModInitializer.cs
+++ b/ConvenientInventory/ConvenientInventory/Compatibility/ModInitializer.cs
@@ -19,7 +19,11 @@ namespace ConvenientInventory.Compatibility
         {
 			api.RegisterModConfig(
 				mod: _modManifest,
-				revertToDefault: () => config = new ModConfig(),
+				revertToDefault: () =>
+				{
+					config = new ModConfig();
+					ModEntry.Config = config;
+				},
 				saveToFile: () => _helper.WriteConfig(config)
 			);
 

--- a/ConvenientInventory/ConvenientInventory/ConvenientInventory.cs
+++ b/ConvenientInventory/ConvenientInventory/ConvenientInventory.cs
@@ -14,635 +14,635 @@ using static StardewValley.Menus.ItemGrabMenu;
 
 namespace ConvenientInventory
 {
-	internal static class CachedTextures
-	{
-		public static Texture2D Mill { get; } = Game1.content.Load<Texture2D>(@"Buildings\Mill");
+    internal static class CachedTextures
+    {
+        public static Texture2D Mill { get; } = Game1.content.Load<Texture2D>(@"Buildings\Mill");
 
-		public static Texture2D JunimoHut { get; } = Game1.content.Load<Texture2D>(@"Buildings\Junimo Hut");
+        public static Texture2D JunimoHut { get; } = Game1.content.Load<Texture2D>(@"Buildings\Junimo Hut");
 
-		public static Texture2D FarmHouse { get; } = Game1.content.Load<Texture2D>(@"Maps\farmhouse_tiles");
-	}
+        public static Texture2D FarmHouse { get; } = Game1.content.Load<Texture2D>(@"Maps\farmhouse_tiles");
+    }
 
-	public static class ConvenientInventory
-	{
-		public static Texture2D QuickStackButtonIcon { private get; set; }
+    public static class ConvenientInventory
+    {
+        public static Texture2D QuickStackButtonIcon { private get; set; }
 
-		private static IReadOnlyList<TypedChest> NearbyTypedChests { get; set; }
+        private static IReadOnlyList<TypedChest> NearbyTypedChests { get; set; }
 
-		private static ClickableTextureComponent QuickStackButton { get; set; }
+        private static ClickableTextureComponent QuickStackButton { get; set; }
 
-		private static readonly PerScreen<InventoryPage> playerInventoryPage = new();
-		private static InventoryPage PlayerInventoryPage
-		{
-			get { return playerInventoryPage.Value; }
-			set { playerInventoryPage.Value = value; }
-		}
+        private static readonly PerScreen<InventoryPage> playerInventoryPage = new();
+        private static InventoryPage PlayerInventoryPage
+        {
+            get { return playerInventoryPage.Value; }
+            set { playerInventoryPage.Value = value; }
+        }
 
-		private static bool IsDrawToolTip { get; set; } = false;
+        private static bool IsDrawToolTip { get; set; } = false;
 
-		private const int quickStackButtonID = 918021;  // Unique indentifier
+        private const int quickStackButtonID = 918021;  // Unique indentifier
 
-		private static readonly List<TransferredItemSprite> transferredItemSprites = new();
+        private static readonly List<TransferredItemSprite> transferredItemSprites = new();
 
-		public static Texture2D FavoriteItemsCursorTexture { private get; set; }
+        public static Texture2D FavoriteItemsCursorTexture { private get; set; }
 
-		public static Texture2D FavoriteItemsHighlightTexture { private get; set; }
+        public static Texture2D FavoriteItemsHighlightTexture { private get; set; }
 
-		public static Texture2D FavoriteItemsBorderTexture { private get; set; }
+        public static Texture2D FavoriteItemsBorderTexture { private get; set; }
 
-		private static readonly PerScreen<bool> isFavoriteItemsHotkeyDown = new();
-		public static bool IsFavoriteItemsHotkeyDown
-		{
-			get { return isFavoriteItemsHotkeyDown.Value; }
-			set { isFavoriteItemsHotkeyDown.Value = value; }
-		}
+        private static readonly PerScreen<bool> isFavoriteItemsHotkeyDown = new();
+        public static bool IsFavoriteItemsHotkeyDown
+        {
+            get { return isFavoriteItemsHotkeyDown.Value; }
+            set { isFavoriteItemsHotkeyDown.Value = value; }
+        }
 
-		private static readonly PerScreen<int> favoriteItemsHotkeyDownCounter = new();
-		private static int FavoriteItemsHotkeyDownCounter
-		{
-			get { return favoriteItemsHotkeyDownCounter.Value; }
-			set { favoriteItemsHotkeyDownCounter.Value = value; }
-		}
+        private static readonly PerScreen<int> favoriteItemsHotkeyDownCounter = new();
+        private static int FavoriteItemsHotkeyDownCounter
+        {
+            get { return favoriteItemsHotkeyDownCounter.Value; }
+            set { favoriteItemsHotkeyDownCounter.Value = value; }
+        }
 
-		private static readonly string favoriteItemSlotsModDataKey = $"{ModEntry.Instance.ModManifest.UniqueID}/favoriteItemSlots";
+        private static readonly string favoriteItemSlotsModDataKey = $"{ModEntry.Instance.ModManifest.UniqueID}/favoriteItemSlots";
 
-		private static readonly PerScreen<bool[]> favoriteItemSlots = new();
-		public static bool[] FavoriteItemSlots
-		{
-			get
-			{
-				if (favoriteItemSlots.Value is null)
+        private static readonly PerScreen<bool[]> favoriteItemSlots = new();
+        public static bool[] FavoriteItemSlots
+        {
+            get
+            {
+                if (favoriteItemSlots.Value is null)
                 {
-					LoadFavoriteItemSlots();
+                    LoadFavoriteItemSlots();
                 }
 
-				if (InventoryExpansions.IsPlayerMaxItemsChanged(favoriteItemSlots.Value))
+                if (InventoryExpansions.IsPlayerMaxItemsChanged(favoriteItemSlots.Value))
                 {
-					favoriteItemSlots.Value = InventoryExpansions.ResizeFavoriteItemSlots(favoriteItemSlots.Value, Game1.player.MaxItems);
+                    favoriteItemSlots.Value = InventoryExpansions.ResizeFavoriteItemSlots(favoriteItemSlots.Value, Game1.player.MaxItems);
                 }
 
-				return favoriteItemSlots.Value;
-			}
-			set { favoriteItemSlots.Value = value; }
-		}
+                return favoriteItemSlots.Value;
+            }
+            set { favoriteItemSlots.Value = value; }
+        }
 
-		private static readonly PerScreen<bool> favoriteItemsIsItemSelected = new();
-		public static bool FavoriteItemsIsItemSelected
-		{
-			get { return favoriteItemsIsItemSelected.Value; }
-			set { favoriteItemsIsItemSelected.Value = value; }
-		}
+        private static readonly PerScreen<bool> favoriteItemsIsItemSelected = new();
+        public static bool FavoriteItemsIsItemSelected
+        {
+            get { return favoriteItemsIsItemSelected.Value; }
+            set { favoriteItemsIsItemSelected.Value = value; }
+        }
 
-		private static readonly PerScreen<int> favoriteItemsLastSelectedSlot = new();
-		public static int FavoriteItemsLastSelectedSlot
-		{
-			get { return favoriteItemsLastSelectedSlot.Value; }
-			set { favoriteItemsLastSelectedSlot.Value = value; }
-		}
+        private static readonly PerScreen<int> favoriteItemsLastSelectedSlot = new();
+        public static int FavoriteItemsLastSelectedSlot
+        {
+            get { return favoriteItemsLastSelectedSlot.Value; }
+            set { favoriteItemsLastSelectedSlot.Value = value; }
+        }
 
-		public static bool[] LoadFavoriteItemSlots()
-		{
-			Game1.player.modData.TryGetValue(favoriteItemSlotsModDataKey, out string dataStr);
-			
-			FavoriteItemSlots = dataStr?
-				.Select(x => x == '1')
-				.ToArray()
-				?? new bool[Game1.player.MaxItems];
+        public static bool[] LoadFavoriteItemSlots()
+        {
+            Game1.player.modData.TryGetValue(favoriteItemSlotsModDataKey, out string dataStr);
 
-			dataStr ??= new string('0', FavoriteItemSlots.Length);
-			ModEntry.Instance.Monitor.Log($"Favorite item slots loaded for {Game1.player.Name}: '{dataStr}'.", StardewModdingAPI.LogLevel.Trace);
-			return FavoriteItemSlots;
-		}
+            FavoriteItemSlots = dataStr?
+                .Select(x => x == '1')
+                .ToArray()
+                ?? new bool[Game1.player.MaxItems];
 
-		public static string SaveFavoriteItemSlots()
-		{
-			if (FavoriteItemSlots is null)
+            dataStr ??= new string('0', FavoriteItemSlots.Length);
+            ModEntry.Instance.Monitor.Log($"Favorite item slots loaded for {Game1.player.Name}: '{dataStr}'.", StardewModdingAPI.LogLevel.Trace);
+            return FavoriteItemSlots;
+        }
+
+        public static string SaveFavoriteItemSlots()
+        {
+            if (FavoriteItemSlots is null)
             {
-				LoadFavoriteItemSlots();
-			}
+                LoadFavoriteItemSlots();
+            }
 
-			var saveStr = new string(FavoriteItemSlots.Select(x => x ? '1' : '0').ToArray());
+            var saveStr = new string(FavoriteItemSlots.Select(x => x ? '1' : '0').ToArray());
 
-			Game1.player.modData[favoriteItemSlotsModDataKey] = saveStr;
+            Game1.player.modData[favoriteItemSlotsModDataKey] = saveStr;
 
-			ModEntry.Instance.Monitor.Log($"Favorite item slots saved to {Game1.player.Name}.modData: '{saveStr}'.", StardewModdingAPI.LogLevel.Trace);
-			return saveStr;
-		}
+            ModEntry.Instance.Monitor.Log($"Favorite item slots saved to {Game1.player.Name}.modData: '{saveStr}'.", StardewModdingAPI.LogLevel.Trace);
+            return saveStr;
+        }
 
-		public static void InventoryPageConstructor(InventoryPage inventoryPage, int x, int y, int width, int height)
-		{
-			PlayerInventoryPage = inventoryPage;
+        public static void InventoryPageConstructor(InventoryPage inventoryPage, int x, int y, int width, int height)
+        {
+            PlayerInventoryPage = inventoryPage;
 
-			if (ModEntry.Config.IsEnableQuickStack)
+            if (ModEntry.Config.IsEnableQuickStack)
             {
-				QuickStackButton = new ClickableTextureComponent("",
-					new Rectangle(inventoryPage.xPositionOnScreen + width, inventoryPage.yPositionOnScreen + height / 3 - 64 + 8 + 80, 64, 64),
-					string.Empty,
-					"Quick Stack To Nearby Chests",
-					QuickStackButtonIcon,
-					Rectangle.Empty,
-					4f,
-					false)
-				{
-					myID = quickStackButtonID,
-					downNeighborID = 105,  // trash can
-					upNeighborID = 106,  // organize button
-					leftNeighborID = 11  // top-right inventory slot
-				};
+                QuickStackButton = new ClickableTextureComponent("",
+                    new Rectangle(inventoryPage.xPositionOnScreen + width, inventoryPage.yPositionOnScreen + height / 3 - 64 + 8 + 80, 64, 64),
+                    string.Empty,
+                    "Quick Stack To Nearby Chests",
+                    QuickStackButtonIcon,
+                    Rectangle.Empty,
+                    4f,
+                    false)
+                {
+                    myID = quickStackButtonID,
+                    downNeighborID = 105,  // trash can
+                    upNeighborID = 106,  // organize button
+                    leftNeighborID = 11  // top-right inventory slot
+                };
 
-				inventoryPage.organizeButton.downNeighborID = quickStackButtonID;
-				inventoryPage.trashCan.upNeighborID = quickStackButtonID;
-			}
-		}
+                inventoryPage.organizeButton.downNeighborID = quickStackButtonID;
+                inventoryPage.trashCan.upNeighborID = quickStackButtonID;
+            }
+        }
 
-		public static bool PreReceiveLeftClickInMenu<T>(T menu, int x, int y) where T : IClickableMenu
-		{
-			if (ModEntry.Config.IsEnableFavoriteItems)
-			{
-				InventoryMenu inventory = (menu as InventoryPage)?.inventory    // Player menu - inventory tab
-					?? (menu as CraftingPage)?.inventory                        // Player menu - crafting tab
-					?? (menu as ShopMenu)?.inventory							// Shop menu
-					?? (menu as MenuWithInventory)?.inventory;                  // Arbitrary menu
+        public static bool PreReceiveLeftClickInMenu<T>(T menu, int x, int y) where T : IClickableMenu
+        {
+            if (ModEntry.Config.IsEnableFavoriteItems)
+            {
+                InventoryMenu inventory = (menu as InventoryPage)?.inventory    // Player menu - inventory tab
+                    ?? (menu as CraftingPage)?.inventory                        // Player menu - crafting tab
+                    ?? (menu as ShopMenu)?.inventory                            // Shop menu
+                    ?? (menu as MenuWithInventory)?.inventory;                  // Arbitrary menu
 
-				if (IsFavoriteItemsHotkeyDown)
-				{
-					return !ToggleFavoriteItemSlotAtClickPosition(inventory, x, y);
-				}
+                if (IsFavoriteItemsHotkeyDown)
+                {
+                    return !ToggleFavoriteItemSlotAtClickPosition(inventory, x, y);
+                }
                 else
                 {
-					TrackSelectedFavoriteItemSlotAtClickPosition(inventory, x, y);
+                    TrackSelectedFavoriteItemSlotAtClickPosition(inventory, x, y);
                 }
-			}
+            }
 
-			return true;
-		}
+            return true;
+        }
 
-		public static bool PreReceiveRightClickInMenu<T>(T menu, int x, int y) where T : IClickableMenu
-		{
-			if (ModEntry.Config.IsEnableFavoriteItems)
-			{
-				if (IsFavoriteItemsHotkeyDown)
-				{
-					return false;
-				}
+        public static bool PreReceiveRightClickInMenu<T>(T menu, int x, int y) where T : IClickableMenu
+        {
+            if (ModEntry.Config.IsEnableFavoriteItems)
+            {
+                if (IsFavoriteItemsHotkeyDown)
+                {
+                    return false;
+                }
 
-				InventoryMenu inventory = (menu as InventoryPage)?.inventory    // Player menu - inventory tab
-					?? (menu as CraftingPage)?.inventory                        // Player menu - crafting tab
-					?? (menu as ShopMenu)?.inventory                            // Shop menu
-					?? (menu as MenuWithInventory)?.inventory;                  // Arbitrary menu
+                InventoryMenu inventory = (menu as InventoryPage)?.inventory    // Player menu - inventory tab
+                    ?? (menu as CraftingPage)?.inventory                        // Player menu - crafting tab
+                    ?? (menu as ShopMenu)?.inventory                            // Shop menu
+                    ?? (menu as MenuWithInventory)?.inventory;                  // Arbitrary menu
 
-				TrackSelectedFavoriteItemSlotAtClickPosition(inventory, x, y, isRightClick: true);
-			}
+                TrackSelectedFavoriteItemSlotAtClickPosition(inventory, x, y, isRightClick: true);
+            }
 
-			return true;
-		}
+            return true;
+        }
 
-		// Toggles the favorited status of a selected item slot. Returns whether an item was toggled.
-		private static bool ToggleFavoriteItemSlotAtClickPosition(InventoryMenu inventoryMenu, int clickX, int clickY, bool? favoriteOverride = null)
-		{
-			if (inventoryMenu is null)
-			{
-				return false;
-			}
+        // Toggles the favorited status of a selected item slot. Returns whether an item was toggled.
+        private static bool ToggleFavoriteItemSlotAtClickPosition(InventoryMenu inventoryMenu, int clickX, int clickY, bool? favoriteOverride = null)
+        {
+            if (inventoryMenu is null)
+            {
+                return false;
+            }
 
-			int clickPos = inventoryMenu.getInventoryPositionOfClick(clickX, clickY);
+            int clickPos = inventoryMenu.getInventoryPositionOfClick(clickX, clickY);
 
-			// Only allow favoriting if selected slot contains an item. Always allow unfavoriting.
-			if (clickPos != -1 && inventoryMenu.actualInventory.Count > clickPos && (FavoriteItemSlots[clickPos] || inventoryMenu.actualInventory[clickPos] != null))
+            // Only allow favoriting if selected slot contains an item. Always allow unfavoriting.
+            if (clickPos != -1 && inventoryMenu.actualInventory.Count > clickPos && (FavoriteItemSlots[clickPos] || inventoryMenu.actualInventory[clickPos] != null))
             {
                 ModEntry.Instance.Monitor
-					.Log($"{(FavoriteItemSlots[clickPos] ? "Un-" : string.Empty)}Favorited item slot {clickPos}: {inventoryMenu.actualInventory[clickPos]?.Name}",
-                	StardewModdingAPI.LogLevel.Trace);
+                    .Log($"{(FavoriteItemSlots[clickPos] ? "Un-" : string.Empty)}Favorited item slot {clickPos}: {inventoryMenu.actualInventory[clickPos]?.Name}",
+                    StardewModdingAPI.LogLevel.Trace);
 
-				Game1.playSound("smallSelect");
+                Game1.playSound("smallSelect");
 
-				FavoriteItemSlots[clickPos] = (favoriteOverride is null)
-					? !FavoriteItemSlots[clickPos]
-					: favoriteOverride.Value;
+                FavoriteItemSlots[clickPos] = (favoriteOverride is null)
+                    ? !FavoriteItemSlots[clickPos]
+                    : favoriteOverride.Value;
 
-				return true;
+                return true;
             }
 
-			return false;
+            return false;
         }
 
-		// Tracks and "moves" favorite item slots when selecting/de-selecting items in an inventory menu.
-		private static bool TrackSelectedFavoriteItemSlotAtClickPosition(InventoryMenu inventoryMenu, int clickX, int clickY, bool isRightClick = false)
-		{
-			if (!ModEntry.Config.IsEnableFavoriteItems || IsFavoriteItemsHotkeyDown || inventoryMenu is null)
-			{
-				return false;
-			}
+        // Tracks and "moves" favorite item slots when selecting/de-selecting items in an inventory menu.
+        private static bool TrackSelectedFavoriteItemSlotAtClickPosition(InventoryMenu inventoryMenu, int clickX, int clickY, bool isRightClick = false)
+        {
+            if (!ModEntry.Config.IsEnableFavoriteItems || IsFavoriteItemsHotkeyDown || inventoryMenu is null)
+            {
+                return false;
+            }
 
-			int clickPos = inventoryMenu.getInventoryPositionOfClick(clickX, clickY);
+            int clickPos = inventoryMenu.getInventoryPositionOfClick(clickX, clickY);
 
-			if (!FavoriteItemsIsItemSelected || isRightClick)
-			{
-				// Check that we've selected a favorited item slot
-				if (clickPos != -1 && inventoryMenu.actualInventory.Count > clickPos && inventoryMenu.actualInventory[clickPos] != null && FavoriteItemSlots[clickPos]) 
-				{
-					Item clickedItem = inventoryMenu.actualInventory[clickPos];
+            if (!FavoriteItemsIsItemSelected || isRightClick)
+            {
+                // Check that we've selected a favorited item slot
+                if (clickPos != -1 && inventoryMenu.actualInventory.Count > clickPos && inventoryMenu.actualInventory[clickPos] != null && FavoriteItemSlots[clickPos])
+                {
+                    Item clickedItem = inventoryMenu.actualInventory[clickPos];
 
-					if (!isRightClick)
-					{
-						if (Game1.oldKBState.IsKeyDown(Keys.LeftShift) && Game1.activeClickableMenu is GameMenu gameMenuIP && gameMenuIP.pages[gameMenuIP.currentTab] is InventoryPage)
-						{
-							// Game logic for shift-clicking in player's inventory page
-							HandleFavoriteItemSlotShiftClickedInInventoryPage(clickPos, clickedItem);
-						}
-						else if (Game1.oldKBState.IsKeyDown(Keys.LeftShift) && Game1.activeClickableMenu is GameMenu gameMenuCP && gameMenuCP.pages[gameMenuCP.currentTab] is CraftingPage
-							&& (clickedItem is Hat || clickedItem is Clothing || clickedItem is Boots || clickedItem is Ring || clickedItem is StardewValley.Tools.MeleeWeapon))
-                        {
-							// Game logic for shift-clicking in player's crafting page. Idk why it works this way, but this handles it.
-							HandleFavoriteItemSlotShiftClickedInCraftingPage(clickPos, clickedItem);
-						}
-						else if ((Game1.player.CursorSlotItem is null || !Game1.player.CursorSlotItem.canStackWith(clickedItem)) && inventoryMenu.highlightMethod(clickedItem))
-						{
-							// Left click with either (1.) no item currently selected, or (2.) item selected that cannot stack with the clicked slot, and (3.) clicked slot is not greyed out.
-							if (!IsCurrentActiveMenuNoHeldItems())
-							{
-								FavoriteItemsLastSelectedSlot = clickPos;
-								FavoriteItemsIsItemSelected = true;
-								FavoriteItemSlots[clickPos] = false;
-							}
-							else
-							{
-								// Shop menus only allow held items after purchasing something, so we check for that case here.
-								if (Game1.activeClickableMenu is ShopMenu shopMenu)
-								{
-									if (shopMenu.heldItem == null && inventoryMenu.highlightMethod(clickedItem))
-									{
-										FavoriteItemSlots[clickPos] = false;
-									}
-								}
-								else
-								{
-									FavoriteItemSlots[clickPos] = false;
-								}
-							}
-						}
-					}
-					else if (isRightClick && clickedItem.Stack == 1 && inventoryMenu.highlightMethod(clickedItem))
-					{
-						// Right click, taking the last item
-						if (!IsCurrentActiveMenuNoHeldItems())
-						{
-							FavoriteItemsLastSelectedSlot = clickPos;
-							FavoriteItemsIsItemSelected = true;
-							FavoriteItemSlots[clickPos] = false;
-						}
-						else
-						{
-							// Shop menus only allow held items after purchasing something, so we check for that case here.
-							if (Game1.activeClickableMenu is ShopMenu shopMenu)
-							{
-								if ((shopMenu.heldItem == null || shopMenu.heldItem.canStackWith(clickedItem)) && inventoryMenu.highlightMethod(clickedItem))
-								{
-									FavoriteItemsLastSelectedSlot = clickPos;
-									FavoriteItemsIsItemSelected = true;
-									FavoriteItemSlots[clickPos] = false;
-								}
-							}
-							else
-							{
-								FavoriteItemSlots[clickPos] = false;
-							}
-						}
-					}
-				}
-			}
-			else
-			{
-				if (clickPos != -1 && inventoryMenu.actualInventory.Count > clickPos && !isRightClick)
-				{
-					// We have a favorited item selected and have clicked a valid inventory slot.
-					Item clickedItem = inventoryMenu.actualInventory[clickPos];
-
-					if (FavoriteItemSlots[clickPos] && clickedItem != null && inventoryMenu.highlightMethod(clickedItem))
+                    if (!isRightClick)
                     {
-						// We are placing the selected favorited item into a favorited slot.
-						if (Game1.player.CursorSlotItem.canStackWith(clickedItem))
-						{
-							// Slot's item can stack with ours, so stop tracking.
-							FavoriteItemsLastSelectedSlot = -1;
-							FavoriteItemsIsItemSelected = false;
-						}
-						else
+                        if (Game1.oldKBState.IsKeyDown(Keys.LeftShift) && Game1.activeClickableMenu is GameMenu gameMenuIP && gameMenuIP.pages[gameMenuIP.currentTab] is InventoryPage)
                         {
-							// Slot's item cannot stack with ours, so swap which item slot we are tracking.
-							FavoriteItemsLastSelectedSlot = clickPos;
-						}
-					}
-					else
-                    {
-						// We are placing the selected favorited item into an empty slot, so stop tracking, and favorite this new slot if necessary.
-						FavoriteItemsLastSelectedSlot = -1;
-						FavoriteItemsIsItemSelected = false;
-
-						if (!FavoriteItemSlots[clickPos])
-						{
-							FavoriteItemSlots[clickPos] = true;
-						}
+                            // Game logic for shift-clicking in player's inventory page
+                            HandleFavoriteItemSlotShiftClickedInInventoryPage(clickPos, clickedItem);
+                        }
+                        else if (Game1.oldKBState.IsKeyDown(Keys.LeftShift) && Game1.activeClickableMenu is GameMenu gameMenuCP && gameMenuCP.pages[gameMenuCP.currentTab] is CraftingPage
+                            && (clickedItem is Hat || clickedItem is Clothing || clickedItem is Boots || clickedItem is Ring || clickedItem is StardewValley.Tools.MeleeWeapon))
+                        {
+                            // Game logic for shift-clicking in player's crafting page. Idk why it works this way, but this handles it.
+                            HandleFavoriteItemSlotShiftClickedInCraftingPage(clickPos, clickedItem);
+                        }
+                        else if ((Game1.player.CursorSlotItem is null || !Game1.player.CursorSlotItem.canStackWith(clickedItem)) && inventoryMenu.highlightMethod(clickedItem))
+                        {
+                            // Left click with either (1.) no item currently selected, or (2.) item selected that cannot stack with the clicked slot, and (3.) clicked slot is not greyed out.
+                            if (!IsCurrentActiveMenuNoHeldItems())
+                            {
+                                FavoriteItemsLastSelectedSlot = clickPos;
+                                FavoriteItemsIsItemSelected = true;
+                                FavoriteItemSlots[clickPos] = false;
+                            }
+                            else
+                            {
+                                // Shop menus only allow held items after purchasing something, so we check for that case here.
+                                if (Game1.activeClickableMenu is ShopMenu shopMenu)
+                                {
+                                    if (shopMenu.heldItem == null && inventoryMenu.highlightMethod(clickedItem))
+                                    {
+                                        FavoriteItemSlots[clickPos] = false;
+                                    }
+                                }
+                                else
+                                {
+                                    FavoriteItemSlots[clickPos] = false;
+                                }
+                            }
+                        }
                     }
-				}
-			}
-
-			return true;
-		}
-
-		// Checks for menus which don't allow selecting and holding items, i.e. chests, shipping bins, shops, etc.
-		private static bool IsCurrentActiveMenuNoHeldItems()
-        {
-			bool result = Game1.activeClickableMenu is ItemGrabMenu
-				|| Game1.activeClickableMenu is ShopMenu;
-
-			return result;
-		}
-
-		// Handles shift-click logic for favorited item slots in player's inventory page.
-		private static bool HandleFavoriteItemSlotShiftClickedInInventoryPage(int clickPos, Item item)
-        {
-			bool isItemEquippable = (item is Ring && (Game1.player.leftRing.Value == null || Game1.player.rightRing.Value == null))
-				|| (item is Hat && Game1.player.hat.Value == null)
-				|| (item is Boots && Game1.player.boots.Value == null)
-				|| (item is Clothing && (((item as Clothing).clothesType.Value == 0 && Game1.player.shirtItem.Value == null)
-									   || (item as Clothing).clothesType.Value == 1 && Game1.player.pantsItem.Value == null));
-
-			if (isItemEquippable)
-			{
-				FavoriteItemSlots[clickPos] = false;
-				return true;
-			}
-			
-			if (clickPos >= 12)
-			{
-				for (int k = 0; k < 12; k++)
-				{
-					if (Game1.player.Items[k] == null || Game1.player.Items[k].canStackWith(item))
-					{
-						FavoriteItemSlots[clickPos] = false;
-						FavoriteItemSlots[k] = true;
-						return true;
-					}
-				}
-			}
-			else if (clickPos < 12)
-			{
-				for (int j = 12; j < Game1.player.Items.Count; j++)
-				{
-					if (Game1.player.Items[j] == null || Game1.player.Items[j].canStackWith(item))
-					{
-						FavoriteItemSlots[clickPos] = false;
-						FavoriteItemSlots[j] = true;
-						return true;
-					}
-				}
-			}
-
-			FavoriteItemsLastSelectedSlot = clickPos;
-			FavoriteItemsIsItemSelected = true;
-			FavoriteItemSlots[clickPos] = false;
-			return false;
-		}
-
-		private static bool HandleFavoriteItemSlotShiftClickedInCraftingPage(int clickPos, Item item)
-		{
-			for (int i = 0; i <= clickPos; i++)
-			{
-				if (i == clickPos)
-                {
-					return true;
-                }
-
-				if (Game1.player.Items[i] == null)
-				{
-					FavoriteItemSlots[clickPos] = false;
-					FavoriteItemSlots[i] = true;
-					return true;
-				}
-			}
-
-			FavoriteItemsLastSelectedSlot = clickPos;
-			FavoriteItemsIsItemSelected = true;
-			FavoriteItemSlots[clickPos] = false;
-			return false;
-		}
-
-		public static void PostReceiveLeftClickInMenu<T>(T menu, int x, int y) where T : IClickableMenu
-		{
-			// Quick stack button clicked (in InventoryPage)
-			if (ModEntry.Config.IsEnableQuickStack && menu is InventoryPage inventoryPage && QuickStackButton != null && QuickStackButton.containsPoint(x, y))
-            {
-				QuickStackLogic.StackToNearbyChests(ModEntry.Config.QuickStackRange, inventoryPage);
-			}
-		}
-
-		public static void OnQuickStackHotkeyPressed()
-        {
-			if (Game1.activeClickableMenu is GameMenu gameMenu && gameMenu.pages[gameMenu.currentTab] is InventoryPage inventoryPage)
-            {
-				QuickStackLogic.StackToNearbyChests(ModEntry.Config.QuickStackRange, inventoryPage);
-				return;
-			}
-
-			QuickStackLogic.StackToNearbyChests(ModEntry.Config.QuickStackRange);
-        }
-
-		// Player shifted toolbar row, so shift all favorited item slots by a row
-		public static void ShiftToolbar(bool right)
-		{
-			RotateArray(FavoriteItemSlots, 12, right);
-		}
-
-		private static void RotateArray(bool[] arr, int count, bool right)
-		{
-			count %= arr.Length;
-			if (count == 0) return;
-
-			bool[] toMove = (bool[]) arr.Clone();
-
-			if (right)
-			{
-				// SDV "right" => left shift
-				for (int i = 0; i < arr.Length - count; i++)
-				{
-					arr[i] = arr[i + count];
-				}
-				for (int i = 0; i < count; i++)
-				{
-					arr[arr.Length - count + i] = toMove[i];
-				}
-
-				return;
-			}
-
-			// SDV "left" => right shift
-			for (int i = 0; i < arr.Length - count; i++)
-			{
-				arr[arr.Length - 1 - i] = arr[arr.Length - 1 - i - count];
-			}
-			for (int i = 0; i < count; i++)
-			{
-				arr[i] = toMove[arr.Length - count + i];
-			}
-
-			return;
-		}
-
-		public static void PerformHoverActionInInventoryPage(int x, int y)
-		{
-			if (ModEntry.Config.IsEnableQuickStack)
-			{
-				QuickStackButton.tryHover(x, y);
-				IsDrawToolTip = QuickStackButton.containsPoint(x, y);
-			}
-		}
-
-		public static void PopulateClickableComponentsListInInventoryPage(InventoryPage inventoryPage)
-		{
-			if (ModEntry.Config.IsEnableQuickStack)
-			{
-				inventoryPage.allClickableComponents.Add(QuickStackButton);
-			}
-		}
-
-		public static bool IsPlayerInventory(InventoryMenu inventoryMenu)
-		{
-			bool result = inventoryMenu.playerInventory
-				|| (Game1.activeClickableMenu is GameMenu gameMenu && gameMenu.pages?[gameMenu.currentTab] is CraftingPage)  // CraftingPage.inventory has playerInventory = false
-				|| (Game1.activeClickableMenu is ItemGrabMenu itemGrabMenu && itemGrabMenu.inventory == inventoryMenu)  // ItemGrabMenu.inventory is the player's InventoryMenu
-				|| (Game1.activeClickableMenu is ShopMenu);
-
-			return result;
-		}
-
-		// Checks if we are about to remove the final item in a favorited item slot, and if so, unfavorites it.
-		public static void PreFarmerReduceActiveItemByOne(Farmer who)
-        {
-			if (who.CurrentItem?.Stack == 1)
-            {
-				int index = GetPlayerInventoryIndexOfItem(who.CurrentItem);
-
-				if (index != -1)
-				{
-					FavoriteItemSlots[index] = false;
-				}
-            }
-		}
-
-		// Called when an inventory's Organize button is clicked.
-		// Extracts an inventory's favorited items (replacing with null), to be re-inserted after organization is completed.
-		public static Item[] ExtractFavoriteItemsFromList(IList<Item> items)
-        {
-			if (items is null)
-			{
-				return null;
-			}
-
-			Item[] extractedItems = new Item[items.Count];
-
-			for (int i = 0; i < items.Count && i < FavoriteItemSlots.Length; i++)
-            {
-				if (FavoriteItemSlots[i])
-                {
-					extractedItems[i] = items[i];
-					items[i] = null;
-                }
-            }
-
-			return extractedItems;
-		}
-
-		// Called after an inventory's Organize button is clicked.
-		// Re-inserts an inventory's favorited items that were extracted before organization began.
-		public static void ReinsertExtractedFavoriteItemsIntoList(Item[] extractedItems, IList<Item> items, bool isSorted = true)
-		{
-			if (extractedItems is null || items is null)
-			{
-				return;
-			}
-
-			for (int i = 0; i < items.Count; i++)
-			{
-				if (extractedItems[i] != null)
-				{
-					if (isSorted)
+                    else if (isRightClick && clickedItem.Stack == 1 && inventoryMenu.highlightMethod(clickedItem))
                     {
-						// Inventory has been organized since we originally extracted favorite items, so we use Insert()
-						items.Insert(i, extractedItems[i]);
+                        // Right click, taking the last item
+                        if (!IsCurrentActiveMenuNoHeldItems())
+                        {
+                            FavoriteItemsLastSelectedSlot = clickPos;
+                            FavoriteItemsIsItemSelected = true;
+                            FavoriteItemSlots[clickPos] = false;
+                        }
+                        else
+                        {
+                            // Shop menus only allow held items after purchasing something, so we check for that case here.
+                            if (Game1.activeClickableMenu is ShopMenu shopMenu)
+                            {
+                                if ((shopMenu.heldItem == null || shopMenu.heldItem.canStackWith(clickedItem)) && inventoryMenu.highlightMethod(clickedItem))
+                                {
+                                    FavoriteItemsLastSelectedSlot = clickPos;
+                                    FavoriteItemsIsItemSelected = true;
+                                    FavoriteItemSlots[clickPos] = false;
+                                }
+                            }
+                            else
+                            {
+                                FavoriteItemSlots[clickPos] = false;
+                            }
+                        }
+                    }
+                }
+            }
+            else
+            {
+                if (clickPos != -1 && inventoryMenu.actualInventory.Count > clickPos && !isRightClick)
+                {
+                    // We have a favorited item selected and have clicked a valid inventory slot.
+                    Item clickedItem = inventoryMenu.actualInventory[clickPos];
 
-						if (items[items.Count - 1] != null)
-						{
-							// This "Item" should always be null (so this case should never happen), but just in case...
-							Game1.playSound("throwDownITem");
-							Game1.createItemDebris(items[items.Count - 1], Game1.player.getStandingPosition(), Game1.player.FacingDirection)
-								.DroppedByPlayerID.Value = Game1.player.UniqueMultiplayerID;
-
-							ModEntry.Instance.Monitor
-								.Log($"Found non-null item: '{items[items.Count - 1].Name}' (x {items[items.Count - 1].Stack}) out of bounds of inventory list (index={i}) " +
-								"when re-inserting extracted favorite items. The item was manually dropped; this may have resulted in unexpected behavior.",
-								StardewModdingAPI.LogLevel.Warn);
-						}
-
-						// Remove the null "Item" we just pushed past the end of the list
-						items.RemoveAt(items.Count - 1);
-					}
+                    if (FavoriteItemSlots[clickPos] && clickedItem != null && inventoryMenu.highlightMethod(clickedItem))
+                    {
+                        // We are placing the selected favorited item into a favorited slot.
+                        if (Game1.player.CursorSlotItem.canStackWith(clickedItem))
+                        {
+                            // Slot's item can stack with ours, so stop tracking.
+                            FavoriteItemsLastSelectedSlot = -1;
+                            FavoriteItemsIsItemSelected = false;
+                        }
+                        else
+                        {
+                            // Slot's item cannot stack with ours, so swap which item slot we are tracking.
+                            FavoriteItemsLastSelectedSlot = clickPos;
+                        }
+                    }
                     else
                     {
-						// Inventory is the same as when we originally extracted favorite items, so we can manually place the items back in
-						if (items[i] != null)
-						{
-							// This "Item" should always be null (so this case should never happen), but just in case...
-							Game1.playSound("throwDownITem");
-							Game1.createItemDebris(items[i], Game1.player.getStandingPosition(), Game1.player.FacingDirection)
-								.DroppedByPlayerID.Value = Game1.player.UniqueMultiplayerID;
+                        // We are placing the selected favorited item into an empty slot, so stop tracking, and favorite this new slot if necessary.
+                        FavoriteItemsLastSelectedSlot = -1;
+                        FavoriteItemsIsItemSelected = false;
 
-							ModEntry.Instance.Monitor
-								.Log($"Found non-null item: '{items[i].Name}' (x {items[i].Stack}) in unexpected position (index={i}) " +
-								"when re-inserting extracted favorite items. The item was manually dropped; this may have resulted in unexpected behavior.",
-								StardewModdingAPI.LogLevel.Warn);
-						}
+                        if (!FavoriteItemSlots[clickPos])
+                        {
+                            FavoriteItemSlots[clickPos] = true;
+                        }
+                    }
+                }
+            }
 
-						items[i] = extractedItems[i];
-					}
-				}
-			}
-		}
+            return true;
+        }
 
-		// Called after drawing everything else in arbitrary inventory menu.
-		// Draws favorite items cursor if keybind is being pressed.
-		public static void PostMenuDraw<T>(T menu, SpriteBatch spriteBatch) where T : IClickableMenu
-		{
-			// Draw quick stack button tooltip (in InventoryPage)
-			if (ModEntry.Config.IsEnableQuickStack && menu is InventoryPage && IsDrawToolTip)
-			{
-				DrawQuickStackButtonToolTip(spriteBatch);
-			}
+        // Checks for menus which don't allow selecting and holding items, i.e. chests, shipping bins, shops, etc.
+        private static bool IsCurrentActiveMenuNoHeldItems()
+        {
+            bool result = Game1.activeClickableMenu is ItemGrabMenu
+                || Game1.activeClickableMenu is ShopMenu;
 
-			if (ModEntry.Config.IsEnableFavoriteItems)
-			{
-				// Get inventory if menu has one
-				InventoryMenu inventory = (menu as InventoryMenu)   // Inventory item slots container
-					?? (menu as InventoryPage)?.inventory           // Player menu - inventory tab
-					?? (menu as CraftingPage)?.inventory            // Player menu - crafting tab
-					?? (menu as ShopMenu)?.inventory				// Shop menu
-					?? (menu as MenuWithInventory)?.inventory;      // Arbitrary menu
+            return result;
+        }
 
-				// Draw favorite cursor (unless this is an InventoryMenu)
-				if (inventory != null && !(menu is InventoryMenu))
-				{
-					if (IsFavoriteItemsHotkeyDown)
-					{
-						DrawFavoriteItemsCursor(spriteBatch);
-						FavoriteItemsHotkeyDownCounter++;
-					}
-					else
-					{
-						FavoriteItemsHotkeyDownCounter = 0;
-					}
-				}
-			}
-		}
+        // Handles shift-click logic for favorited item slots in player's inventory page.
+        private static bool HandleFavoriteItemSlotShiftClickedInInventoryPage(int clickPos, Item item)
+        {
+            bool isItemEquippable = (item is Ring && (Game1.player.leftRing.Value == null || Game1.player.rightRing.Value == null))
+                || (item is Hat && Game1.player.hat.Value == null)
+                || (item is Boots && Game1.player.boots.Value == null)
+                || (item is Clothing && (((item as Clothing).clothesType.Value == 0 && Game1.player.shirtItem.Value == null)
+                                       || (item as Clothing).clothesType.Value == 1 && Game1.player.pantsItem.Value == null));
+
+            if (isItemEquippable)
+            {
+                FavoriteItemSlots[clickPos] = false;
+                return true;
+            }
+
+            if (clickPos >= 12)
+            {
+                for (int k = 0; k < 12; k++)
+                {
+                    if (Game1.player.Items[k] == null || Game1.player.Items[k].canStackWith(item))
+                    {
+                        FavoriteItemSlots[clickPos] = false;
+                        FavoriteItemSlots[k] = true;
+                        return true;
+                    }
+                }
+            }
+            else if (clickPos < 12)
+            {
+                for (int j = 12; j < Game1.player.Items.Count; j++)
+                {
+                    if (Game1.player.Items[j] == null || Game1.player.Items[j].canStackWith(item))
+                    {
+                        FavoriteItemSlots[clickPos] = false;
+                        FavoriteItemSlots[j] = true;
+                        return true;
+                    }
+                }
+            }
+
+            FavoriteItemsLastSelectedSlot = clickPos;
+            FavoriteItemsIsItemSelected = true;
+            FavoriteItemSlots[clickPos] = false;
+            return false;
+        }
+
+        private static bool HandleFavoriteItemSlotShiftClickedInCraftingPage(int clickPos, Item item)
+        {
+            for (int i = 0; i <= clickPos; i++)
+            {
+                if (i == clickPos)
+                {
+                    return true;
+                }
+
+                if (Game1.player.Items[i] == null)
+                {
+                    FavoriteItemSlots[clickPos] = false;
+                    FavoriteItemSlots[i] = true;
+                    return true;
+                }
+            }
+
+            FavoriteItemsLastSelectedSlot = clickPos;
+            FavoriteItemsIsItemSelected = true;
+            FavoriteItemSlots[clickPos] = false;
+            return false;
+        }
+
+        public static void PostReceiveLeftClickInMenu<T>(T menu, int x, int y) where T : IClickableMenu
+        {
+            // Quick stack button clicked (in InventoryPage)
+            if (ModEntry.Config.IsEnableQuickStack && menu is InventoryPage inventoryPage && QuickStackButton != null && QuickStackButton.containsPoint(x, y))
+            {
+                QuickStackLogic.StackToNearbyChests(ModEntry.Config.QuickStackRange, inventoryPage);
+            }
+        }
+
+        public static void OnQuickStackHotkeyPressed()
+        {
+            if (Game1.activeClickableMenu is GameMenu gameMenu && gameMenu.pages[gameMenu.currentTab] is InventoryPage inventoryPage)
+            {
+                QuickStackLogic.StackToNearbyChests(ModEntry.Config.QuickStackRange, inventoryPage);
+                return;
+            }
+
+            QuickStackLogic.StackToNearbyChests(ModEntry.Config.QuickStackRange);
+        }
+
+        // Player shifted toolbar row, so shift all favorited item slots by a row
+        public static void ShiftToolbar(bool right)
+        {
+            RotateArray(FavoriteItemSlots, 12, right);
+        }
+
+        private static void RotateArray(bool[] arr, int count, bool right)
+        {
+            count %= arr.Length;
+            if (count == 0) return;
+
+            bool[] toMove = (bool[])arr.Clone();
+
+            if (right)
+            {
+                // SDV "right" => left shift
+                for (int i = 0; i < arr.Length - count; i++)
+                {
+                    arr[i] = arr[i + count];
+                }
+                for (int i = 0; i < count; i++)
+                {
+                    arr[arr.Length - count + i] = toMove[i];
+                }
+
+                return;
+            }
+
+            // SDV "left" => right shift
+            for (int i = 0; i < arr.Length - count; i++)
+            {
+                arr[arr.Length - 1 - i] = arr[arr.Length - 1 - i - count];
+            }
+            for (int i = 0; i < count; i++)
+            {
+                arr[i] = toMove[arr.Length - count + i];
+            }
+
+            return;
+        }
+
+        public static void PerformHoverActionInInventoryPage(int x, int y)
+        {
+            if (ModEntry.Config.IsEnableQuickStack)
+            {
+                QuickStackButton.tryHover(x, y);
+                IsDrawToolTip = QuickStackButton.containsPoint(x, y);
+            }
+        }
+
+        public static void PopulateClickableComponentsListInInventoryPage(InventoryPage inventoryPage)
+        {
+            if (ModEntry.Config.IsEnableQuickStack)
+            {
+                inventoryPage.allClickableComponents.Add(QuickStackButton);
+            }
+        }
+
+        public static bool IsPlayerInventory(InventoryMenu inventoryMenu)
+        {
+            bool result = inventoryMenu.playerInventory
+                || (Game1.activeClickableMenu is GameMenu gameMenu && gameMenu.pages?[gameMenu.currentTab] is CraftingPage)  // CraftingPage.inventory has playerInventory = false
+                || (Game1.activeClickableMenu is ItemGrabMenu itemGrabMenu && itemGrabMenu.inventory == inventoryMenu)  // ItemGrabMenu.inventory is the player's InventoryMenu
+                || (Game1.activeClickableMenu is ShopMenu);
+
+            return result;
+        }
+
+        // Checks if we are about to remove the final item in a favorited item slot, and if so, unfavorites it.
+        public static void PreFarmerReduceActiveItemByOne(Farmer who)
+        {
+            if (who.CurrentItem?.Stack == 1)
+            {
+                int index = GetPlayerInventoryIndexOfItem(who.CurrentItem);
+
+                if (index != -1)
+                {
+                    FavoriteItemSlots[index] = false;
+                }
+            }
+        }
+
+        // Called when an inventory's Organize button is clicked.
+        // Extracts an inventory's favorited items (replacing with null), to be re-inserted after organization is completed.
+        public static Item[] ExtractFavoriteItemsFromList(IList<Item> items)
+        {
+            if (items is null)
+            {
+                return null;
+            }
+
+            Item[] extractedItems = new Item[items.Count];
+
+            for (int i = 0; i < items.Count && i < FavoriteItemSlots.Length; i++)
+            {
+                if (FavoriteItemSlots[i])
+                {
+                    extractedItems[i] = items[i];
+                    items[i] = null;
+                }
+            }
+
+            return extractedItems;
+        }
+
+        // Called after an inventory's Organize button is clicked.
+        // Re-inserts an inventory's favorited items that were extracted before organization began.
+        public static void ReinsertExtractedFavoriteItemsIntoList(Item[] extractedItems, IList<Item> items, bool isSorted = true)
+        {
+            if (extractedItems is null || items is null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < items.Count; i++)
+            {
+                if (extractedItems[i] != null)
+                {
+                    if (isSorted)
+                    {
+                        // Inventory has been organized since we originally extracted favorite items, so we use Insert()
+                        items.Insert(i, extractedItems[i]);
+
+                        if (items[items.Count - 1] != null)
+                        {
+                            // This "Item" should always be null (so this case should never happen), but just in case...
+                            Game1.playSound("throwDownITem");
+                            Game1.createItemDebris(items[items.Count - 1], Game1.player.getStandingPosition(), Game1.player.FacingDirection)
+                                .DroppedByPlayerID.Value = Game1.player.UniqueMultiplayerID;
+
+                            ModEntry.Instance.Monitor
+                                .Log($"Found non-null item: '{items[items.Count - 1].Name}' (x {items[items.Count - 1].Stack}) out of bounds of inventory list (index={i}) " +
+                                "when re-inserting extracted favorite items. The item was manually dropped; this may have resulted in unexpected behavior.",
+                                StardewModdingAPI.LogLevel.Warn);
+                        }
+
+                        // Remove the null "Item" we just pushed past the end of the list
+                        items.RemoveAt(items.Count - 1);
+                    }
+                    else
+                    {
+                        // Inventory is the same as when we originally extracted favorite items, so we can manually place the items back in
+                        if (items[i] != null)
+                        {
+                            // This "Item" should always be null (so this case should never happen), but just in case...
+                            Game1.playSound("throwDownITem");
+                            Game1.createItemDebris(items[i], Game1.player.getStandingPosition(), Game1.player.FacingDirection)
+                                .DroppedByPlayerID.Value = Game1.player.UniqueMultiplayerID;
+
+                            ModEntry.Instance.Monitor
+                                .Log($"Found non-null item: '{items[i].Name}' (x {items[i].Stack}) in unexpected position (index={i}) " +
+                                "when re-inserting extracted favorite items. The item was manually dropped; this may have resulted in unexpected behavior.",
+                                StardewModdingAPI.LogLevel.Warn);
+                        }
+
+                        items[i] = extractedItems[i];
+                    }
+                }
+            }
+        }
+
+        // Called after drawing everything else in arbitrary inventory menu.
+        // Draws favorite items cursor if keybind is being pressed.
+        public static void PostMenuDraw<T>(T menu, SpriteBatch spriteBatch) where T : IClickableMenu
+        {
+            // Draw quick stack button tooltip (in InventoryPage)
+            if (ModEntry.Config.IsEnableQuickStack && menu is InventoryPage && IsDrawToolTip)
+            {
+                DrawQuickStackButtonToolTip(spriteBatch);
+            }
+
+            if (ModEntry.Config.IsEnableFavoriteItems)
+            {
+                // Get inventory if menu has one
+                InventoryMenu inventory = (menu as InventoryMenu)   // Inventory item slots container
+                    ?? (menu as InventoryPage)?.inventory           // Player menu - inventory tab
+                    ?? (menu as CraftingPage)?.inventory            // Player menu - crafting tab
+                    ?? (menu as ShopMenu)?.inventory                // Shop menu
+                    ?? (menu as MenuWithInventory)?.inventory;      // Arbitrary menu
+
+                // Draw favorite cursor (unless this is an InventoryMenu)
+                if (inventory != null && !(menu is InventoryMenu))
+                {
+                    if (IsFavoriteItemsHotkeyDown)
+                    {
+                        DrawFavoriteItemsCursor(spriteBatch);
+                        FavoriteItemsHotkeyDownCounter++;
+                    }
+                    else
+                    {
+                        FavoriteItemsHotkeyDownCounter = 0;
+                    }
+                }
+            }
+        }
 
         private static void DrawQuickStackButtonToolTip(SpriteBatch spriteBatch)
         {
@@ -665,14 +665,14 @@ namespace ConvenientInventory
             }
         }
 
-		public static void DrawFavoriteItemSlotHighlights(SpriteBatch spriteBatch, InventoryMenu inventoryMenu)
+        public static void DrawFavoriteItemSlotHighlights(SpriteBatch spriteBatch, InventoryMenu inventoryMenu)
         {
-			if (inventoryMenu is null)
+            if (inventoryMenu is null)
             {
-				return;
+                return;
             }
 
-			List<Vector2> slotDrawPositions = inventoryMenu.GetSlotDrawPositions();
+            List<Vector2> slotDrawPositions = inventoryMenu.GetSlotDrawPositions();
 
             for (int i = 0; i < slotDrawPositions.Count && i < FavoriteItemSlots.Length; i++)
             {
@@ -690,175 +690,175 @@ namespace ConvenientInventory
             }
         }
 
-		// Draws favorite item slots in toolbar, and draws current tool red outline and slot text on top of highlight (so we don't cover them up).
-		public static void DrawFavoriteItemSlotHighlightsInToolbar(SpriteBatch spriteBatch, int yPositionOnScreen, float transparency, string[] slotText)
-		{
-			for (int i = 0; i < 12; i++)
-			{
-				if (!FavoriteItemSlots[i])
-				{
-					continue;
-				}
-
-				Vector2 toDraw = new Vector2(Game1.uiViewport.Width / 2 - 384 + i * 64, yPositionOnScreen - 96 + 8);
-
-				spriteBatch.Draw(FavoriteItemsHighlightTexture,
-					toDraw,
-					new Rectangle(0, 0, FavoriteItemsHighlightTexture.Width, FavoriteItemsHighlightTexture.Height),
-					Color.White,
-					0f, Vector2.Zero, 4f, SpriteEffects.None, 1f
-				);
-
-				spriteBatch.DrawString(Game1.tinyFont, slotText[i], toDraw + new Vector2(4f, -8f), Color.DimGray * transparency);
-
-				if (Game1.player.CurrentToolIndex == i)
+        // Draws favorite item slots in toolbar, and draws current tool red outline and slot text on top of highlight (so we don't cover them up).
+        public static void DrawFavoriteItemSlotHighlightsInToolbar(SpriteBatch spriteBatch, int yPositionOnScreen, float transparency, string[] slotText)
+        {
+            for (int i = 0; i < 12; i++)
+            {
+                if (!FavoriteItemSlots[i])
                 {
-					spriteBatch.Draw(Game1.menuTexture,
-						toDraw,
-						Game1.getSourceRectForStandardTileSheet(Game1.menuTexture, 56),
-						Color.White * transparency);
-				}
-			}
-		}
+                    continue;
+                }
 
-		private static void DrawFavoriteItemsCursor(SpriteBatch spriteBatch)
-		{
-			float scale = (float)(3d + 0.15d * Math.Cos(FavoriteItemsHotkeyDownCounter / 15d));
+                Vector2 toDraw = new Vector2(Game1.uiViewport.Width / 2 - 384 + i * 64, yPositionOnScreen - 96 + 8);
 
-			spriteBatch.Draw(FavoriteItemsCursorTexture,
-			   new Vector2(Game1.getOldMouseX() - 32, Game1.getOldMouseY()),
-			   new Rectangle(0, 0, FavoriteItemsCursorTexture.Width, FavoriteItemsCursorTexture.Height),
-			   Color.White,
-			   0f, Vector2.Zero, scale, SpriteEffects.None, 1f
-		   );
-		}
+                spriteBatch.Draw(FavoriteItemsHighlightTexture,
+                    toDraw,
+                    new Rectangle(0, 0, FavoriteItemsHighlightTexture.Width, FavoriteItemsHighlightTexture.Height),
+                    Color.White,
+                    0f, Vector2.Zero, 4f, SpriteEffects.None, 1f
+                );
 
-		public static void DrawFavoriteItemsToolTipBorder(Item item, SpriteBatch spriteBatch, int x, int y)
-		{
-			int index = GetPlayerInventoryIndexOfItem(item);
+                spriteBatch.DrawString(Game1.tinyFont, slotText[i], toDraw + new Vector2(4f, -8f), Color.DimGray * transparency);
 
-			if (ModEntry.Config.IsEnableFavoriteItems && index != -1 && FavoriteItemSlots[index])
-			{
-				spriteBatch.Draw(FavoriteItemsBorderTexture,
-					new Vector2(x, y),
-					new Rectangle(0, 0, FavoriteItemsBorderTexture.Width, FavoriteItemsBorderTexture.Height),
-					Color.White,
-					0f, Vector2.Zero, 4f, SpriteEffects.None, 1f
-				);
-			}
-		}
+                if (Game1.player.CurrentToolIndex == i)
+                {
+                    spriteBatch.Draw(Game1.menuTexture,
+                        toDraw,
+                        Game1.getSourceRectForStandardTileSheet(Game1.menuTexture, 56),
+                        Color.White * transparency);
+                }
+            }
+        }
 
-		public static int GetPlayerInventoryIndexOfItem(Item item)
-		{
-			if (item is null)
+        private static void DrawFavoriteItemsCursor(SpriteBatch spriteBatch)
+        {
+            float scale = (float)(3d + 0.15d * Math.Cos(FavoriteItemsHotkeyDownCounter / 15d));
+
+            spriteBatch.Draw(FavoriteItemsCursorTexture,
+               new Vector2(Game1.getOldMouseX() - 32, Game1.getOldMouseY()),
+               new Rectangle(0, 0, FavoriteItemsCursorTexture.Width, FavoriteItemsCursorTexture.Height),
+               Color.White,
+               0f, Vector2.Zero, scale, SpriteEffects.None, 1f
+           );
+        }
+
+        public static void DrawFavoriteItemsToolTipBorder(Item item, SpriteBatch spriteBatch, int x, int y)
+        {
+            int index = GetPlayerInventoryIndexOfItem(item);
+
+            if (ModEntry.Config.IsEnableFavoriteItems && index != -1 && FavoriteItemSlots[index])
             {
-				return -1;
+                spriteBatch.Draw(FavoriteItemsBorderTexture,
+                    new Vector2(x, y),
+                    new Rectangle(0, 0, FavoriteItemsBorderTexture.Width, FavoriteItemsBorderTexture.Height),
+                    Color.White,
+                    0f, Vector2.Zero, 4f, SpriteEffects.None, 1f
+                );
+            }
+        }
+
+        public static int GetPlayerInventoryIndexOfItem(Item item)
+        {
+            if (item is null)
+            {
+                return -1;
             }
 
-			for (int i = 0; i < Game1.player.Items.Count; i++)
-			{
-				if (Game1.player.Items[i] == item && Game1.player.Items[i] != null)
-				{
-					return i;
-				}
-			}
-
-			return -1;
-		}
-
-		public static void PostClickableTextureComponentDraw(ClickableTextureComponent textureComponent, SpriteBatch spriteBatch)
-		{
-			// Check if we have just drawn the trash can for this inventory page, which happens before in-game tooltip is drawn.
-			if (PlayerInventoryPage?.trashCan != textureComponent)
+            for (int i = 0; i < Game1.player.Items.Count; i++)
             {
-				return;
+                if (Game1.player.Items[i] == item && Game1.player.Items[i] != null)
+                {
+                    return i;
+                }
             }
 
-			if (ModEntry.Config.IsEnableQuickStack)
-			{
-				// Draw transferred item sprites
-				foreach (TransferredItemSprite transferredItemSprite in transferredItemSprites)
-				{
-					transferredItemSprite.Draw(spriteBatch);
-				}
+            return -1;
+        }
 
-				QuickStackButton?.draw(spriteBatch);
-			}
-		}
+        public static void PostClickableTextureComponentDraw(ClickableTextureComponent textureComponent, SpriteBatch spriteBatch)
+        {
+            // Check if we have just drawn the trash can for this inventory page, which happens before in-game tooltip is drawn.
+            if (PlayerInventoryPage?.trashCan != textureComponent)
+            {
+                return;
+            }
+
+            if (ModEntry.Config.IsEnableQuickStack)
+            {
+                // Draw transferred item sprites
+                foreach (TransferredItemSprite transferredItemSprite in transferredItemSprites)
+                {
+                    transferredItemSprite.Draw(spriteBatch);
+                }
+
+                QuickStackButton?.draw(spriteBatch);
+            }
+        }
 
         private static int GetExtraNumPosUsedByBuildingChests(IReadOnlyList<TypedChest> chests)
         {
-			int extraNumPos = 0;
+            int extraNumPos = 0;
 
-			for (int i=0; i<chests.Count; i++)
+            for (int i = 0; i < chests.Count; i++)
             {
-				if (chests[i] is null)
+                if (chests[i] is null)
                 {
-					continue;
+                    continue;
                 }
 
-				extraNumPos += TypedChest.IsBuildingChestType(chests[i].ChestType)
-					? 1 + ((i % 8 == 7) ? 1 : 0)
-					: 0;
+                extraNumPos += TypedChest.IsBuildingChestType(chests[i].ChestType)
+                    ? 1 + ((i % 8 == 7) ? 1 : 0)
+                    : 0;
             }
 
-			return extraNumPos;
+            return extraNumPos;
         }
 
-		private static void DrawTypedChestsInToolTip(SpriteBatch spriteBatch, IReadOnlyList<TypedChest> typedChests)
-		{
-			Point toolTipPosition = GetToolTipDrawPosition(QuickStackButton.hoverText);
-
-			for (int i = 0, pos = 0; i < typedChests.Count; i++, pos++)
-			{
-				pos += typedChests[i]?.DrawInToolTip(spriteBatch, toolTipPosition, pos) ?? 0;
-			}
-		}
-
-		// Refactored from IClickableMenu drawHoverText()
-		// Finds the origin position of where a tooltip will be drawn.
-		private static Point GetToolTipDrawPosition(string text)
+        private static void DrawTypedChestsInToolTip(SpriteBatch spriteBatch, IReadOnlyList<TypedChest> typedChests)
         {
-			int width = (int)Game1.smallFont.MeasureString(text).X + 32;
-			int height = Math.Max(20 * 3, (int)Game1.smallFont.MeasureString(text).Y + 32 + 8);
+            Point toolTipPosition = GetToolTipDrawPosition(QuickStackButton.hoverText);
 
-			int x = Game1.getOldMouseX() + 32;
-			int y = Game1.getOldMouseY() + 32;
-			
-			if (x + width > Utility.getSafeArea().Right)
-			{
-				x = Utility.getSafeArea().Right - width;
-				y += 16;
-			}
-			if (y + height > Utility.getSafeArea().Bottom)
-			{
-				x += 16;
-				if (x + width > Utility.getSafeArea().Right)
-				{
-					x = Utility.getSafeArea().Right - width;
-				}
-				y = Utility.getSafeArea().Bottom - height;
-			}
+            for (int i = 0, pos = 0; i < typedChests.Count; i++, pos++)
+            {
+                pos += typedChests[i]?.DrawInToolTip(spriteBatch, toolTipPosition, pos) ?? 0;
+            }
+        }
 
-			return new Point(x, y);
-		}
+        // Refactored from IClickableMenu drawHoverText()
+        // Finds the origin position of where a tooltip will be drawn.
+        private static Point GetToolTipDrawPosition(string text)
+        {
+            int width = (int)Game1.smallFont.MeasureString(text).X + 32;
+            int height = Math.Max(20 * 3, (int)Game1.smallFont.MeasureString(text).Y + 32 + 8);
+
+            int x = Game1.getOldMouseX() + 32;
+            int y = Game1.getOldMouseY() + 32;
+
+            if (x + width > Utility.getSafeArea().Right)
+            {
+                x = Utility.getSafeArea().Right - width;
+                y += 16;
+            }
+            if (y + height > Utility.getSafeArea().Bottom)
+            {
+                x += 16;
+                if (x + width > Utility.getSafeArea().Right)
+                {
+                    x = Utility.getSafeArea().Right - width;
+                }
+                y = Utility.getSafeArea().Bottom - height;
+            }
+
+            return new Point(x, y);
+        }
 
         // Updates transferredItemSprite animation
         public static void Update(GameTime time)
-		{
-			for (int i = 0; i < transferredItemSprites.Count; i++)
-			{
-				if (transferredItemSprites[i].Update(time))
-				{
-					transferredItemSprites.RemoveAt(i);
-					i--;
-				}
-			}
-		}
+        {
+            for (int i = 0; i < transferredItemSprites.Count; i++)
+            {
+                if (transferredItemSprites[i].Update(time))
+                {
+                    transferredItemSprites.RemoveAt(i);
+                    i--;
+                }
+            }
+        }
 
-		public static void AddTransferredItemSprite(TransferredItemSprite itemSprite)
-		{
-			transferredItemSprites.Add(itemSprite);
-		}
-	}
+        public static void AddTransferredItemSprite(TransferredItemSprite itemSprite)
+        {
+            transferredItemSprites.Add(itemSprite);
+        }
+    }
 }

--- a/ConvenientInventory/ConvenientInventory/ConvenientInventory.cs
+++ b/ConvenientInventory/ConvenientInventory/ConvenientInventory.cs
@@ -64,7 +64,7 @@ namespace ConvenientInventory
 			set { favoriteItemsHotkeyDownCounter.Value = value; }
 		}
 
-		private static readonly string favoriteItemSlotsModDataKey = $"{ModEntry.Context.ModManifest.UniqueID}/favoriteItemSlots";
+		private static readonly string favoriteItemSlotsModDataKey = $"{ModEntry.Instance.ModManifest.UniqueID}/favoriteItemSlots";
 
 		private static readonly PerScreen<bool[]> favoriteItemSlots = new();
 		public static bool[] FavoriteItemSlots
@@ -110,7 +110,7 @@ namespace ConvenientInventory
 				?? new bool[Game1.player.MaxItems];
 
 			dataStr ??= new string('0', FavoriteItemSlots.Length);
-			ModEntry.Context.Monitor.Log($"Favorite item slots loaded for {Game1.player.Name}: '{dataStr}'.", StardewModdingAPI.LogLevel.Trace);
+			ModEntry.Instance.Monitor.Log($"Favorite item slots loaded for {Game1.player.Name}: '{dataStr}'.", StardewModdingAPI.LogLevel.Trace);
 			return FavoriteItemSlots;
 		}
 
@@ -125,7 +125,7 @@ namespace ConvenientInventory
 
 			Game1.player.modData[favoriteItemSlotsModDataKey] = saveStr;
 
-			ModEntry.Context.Monitor.Log($"Favorite item slots saved to {Game1.player.Name}.modData: '{saveStr}'.", StardewModdingAPI.LogLevel.Trace);
+			ModEntry.Instance.Monitor.Log($"Favorite item slots saved to {Game1.player.Name}.modData: '{saveStr}'.", StardewModdingAPI.LogLevel.Trace);
 			return saveStr;
 		}
 
@@ -210,7 +210,7 @@ namespace ConvenientInventory
 			// Only allow favoriting if selected slot contains an item. Always allow unfavoriting.
 			if (clickPos != -1 && inventoryMenu.actualInventory.Count > clickPos && (FavoriteItemSlots[clickPos] || inventoryMenu.actualInventory[clickPos] != null))
             {
-                ModEntry.Context.Monitor
+                ModEntry.Instance.Monitor
 					.Log($"{(FavoriteItemSlots[clickPos] ? "Un-" : string.Empty)}Favorited item slot {clickPos}: {inventoryMenu.actualInventory[clickPos]?.Name}",
                 	StardewModdingAPI.LogLevel.Trace);
 
@@ -437,7 +437,7 @@ namespace ConvenientInventory
 			}
 		}
 
-		public static void QuickStackHotkeyPressed()
+		public static void OnQuickStackHotkeyPressed()
         {
 			if (Game1.activeClickableMenu is GameMenu gameMenu && gameMenu.pages[gameMenu.currentTab] is InventoryPage inventoryPage)
             {
@@ -578,7 +578,7 @@ namespace ConvenientInventory
 							Game1.createItemDebris(items[items.Count - 1], Game1.player.getStandingPosition(), Game1.player.FacingDirection)
 								.DroppedByPlayerID.Value = Game1.player.UniqueMultiplayerID;
 
-							ModEntry.Context.Monitor
+							ModEntry.Instance.Monitor
 								.Log($"Found non-null item: '{items[items.Count - 1].Name}' (x {items[items.Count - 1].Stack}) out of bounds of inventory list (index={i}) " +
 								"when re-inserting extracted favorite items. The item was manually dropped; this may have resulted in unexpected behavior.",
 								StardewModdingAPI.LogLevel.Warn);
@@ -597,7 +597,7 @@ namespace ConvenientInventory
 							Game1.createItemDebris(items[i], Game1.player.getStandingPosition(), Game1.player.FacingDirection)
 								.DroppedByPlayerID.Value = Game1.player.UniqueMultiplayerID;
 
-							ModEntry.Context.Monitor
+							ModEntry.Instance.Monitor
 								.Log($"Found non-null item: '{items[i].Name}' (x {items[i].Stack}) in unexpected position (index={i}) " +
 								"when re-inserting extracted favorite items. The item was manually dropped; this may have resulted in unexpected behavior.",
 								StardewModdingAPI.LogLevel.Warn);

--- a/ConvenientInventory/ConvenientInventory/ConvenientInventory.csproj
+++ b/ConvenientInventory/ConvenientInventory/ConvenientInventory.csproj
@@ -6,78 +6,21 @@
     <AssemblyName>ConvenientInventory</AssemblyName>
     <RootNamespace>ConvenientInventory</RootNamespace>
     <Version>1.0.0</Version>
-    <!--<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>-->
-    <!--<Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>-->
-    <!--<ProjectGuid>{287A38BF-C277-4F67-8D15-C7CBE4231BB6}</ProjectGuid>-->
     <TargetFramework>net5.0</TargetFramework>
-    <!--<FileAlignment>512</FileAlignment>-->
-    <!--<Deterministic>true</Deterministic>-->
-    <!--<NuGetPackageImportStamp></NuGetPackageImportStamp>-->
   </PropertyGroup>
-  <!--<PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
-    <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\x64\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <Optimize>true</Optimize>
-    <DebugType>pdbonly</DebugType>
-    <PlatformTarget>x64</PlatformTarget>
-    <LangVersion>7.3</LangVersion>
-    <ErrorReport>prompt</ErrorReport>
-  </PropertyGroup>-->
-  <!--<ItemGroup>
-    <Reference Include="Microsoft.Build" />
-    <Reference Include="Microsoft.Build.Framework" />
-    <Reference Include="Microsoft.Build.Utilities.v4.0" />
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.IO.Compression" />
-    <Reference Include="System.Web.Extensions" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>-->
   <ItemGroup>
     <PackageReference Include="Pathoschild.Stardew.ModBuildConfig" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <Content Include="Assets\favoriteBorder.png" />
-    <Content Include="Assets\favoriteCursor.png" />
-    <Content Include="Assets\favoriteHighlight_0.png" />
-    <Content Include="Assets\favoriteHighlight_1.png" />
-    <Content Include="Assets\favoriteHighlight_2.png" />
-    <Content Include="Assets\favoriteHighlight_3.png" />
-    <Content Include="Assets\favoriteHighlight_4.png" />
-    <Content Include="Assets\favoriteHighlight_5.png" />
-    <Content Include="Assets\icon.png" />
+    <Content Include="assets\favoriteBorder.png" />
+    <Content Include="assets\favoriteCursor.png" />
+    <Content Include="assets\favoriteHighlight_0.png" />
+    <Content Include="assets\favoriteHighlight_1.png" />
+    <Content Include="assets\favoriteHighlight_2.png" />
+    <Content Include="assets\favoriteHighlight_3.png" />
+    <Content Include="assets\favoriteHighlight_4.png" />
+    <Content Include="assets\favoriteHighlight_5.png" />
+    <Content Include="assets\icon.png" />
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json" />

--- a/ConvenientInventory/ConvenientInventory/ModConfig.cs
+++ b/ConvenientInventory/ConvenientInventory/ModConfig.cs
@@ -18,7 +18,7 @@ namespace ConvenientInventory
 
 		public SButton QuickStackKeyboardHotkey { get; set; } = SButton.K;
 
-		public SButton QuickStackControllerHotkey { get; set; } = SButton.None;
+		public SButton QuickStackControllerHotkey { get; set; } = SButton.LeftStick;
 
 		public bool IsEnableFavoriteItems { get; set; } = true;
 
@@ -26,6 +26,6 @@ namespace ConvenientInventory
 
 		public SButton FavoriteItemsKeyboardHotkey { get; set; } = SButton.LeftAlt;
 
-		public SButton FavoriteItemsControllerHotkey { get; set; } = SButton.LeftStick;
+		public SButton FavoriteItemsControllerHotkey { get; set; } = SButton.LeftShoulder;
 	}
 }

--- a/ConvenientInventory/ConvenientInventory/ModConfig.cs
+++ b/ConvenientInventory/ConvenientInventory/ModConfig.cs
@@ -14,6 +14,12 @@ namespace ConvenientInventory
 
 		public bool IsQuickStackTooltipDrawNearbyChests { get; set; } = true;
 
+		public bool IsEnableQuickStackHotkey { get; set; } = false;  // TODO
+
+		public SButton QuickStackKeyboardHotkey { get; set; } = SButton.K;  // TODO
+
+		public SButton QuickStackControllerHotkey { get; set; } = SButton.None;  // TODO
+
 		public bool IsEnableFavoriteItems { get; set; } = true;
 
 		public int FavoriteItemsHighlightTextureChoice { get; set; } = 2;

--- a/ConvenientInventory/ConvenientInventory/ModConfig.cs
+++ b/ConvenientInventory/ConvenientInventory/ModConfig.cs
@@ -14,11 +14,11 @@ namespace ConvenientInventory
 
 		public bool IsQuickStackTooltipDrawNearbyChests { get; set; } = true;
 
-		public bool IsEnableQuickStackHotkey { get; set; } = false;  // TODO
+		public bool IsEnableQuickStackHotkey { get; set; } = false;
 
-		public SButton QuickStackKeyboardHotkey { get; set; } = SButton.K;  // TODO
+		public SButton QuickStackKeyboardHotkey { get; set; } = SButton.K;
 
-		public SButton QuickStackControllerHotkey { get; set; } = SButton.None;  // TODO
+		public SButton QuickStackControllerHotkey { get; set; } = SButton.None;
 
 		public bool IsEnableFavoriteItems { get; set; } = true;
 

--- a/ConvenientInventory/ConvenientInventory/ModConfig.cs
+++ b/ConvenientInventory/ConvenientInventory/ModConfig.cs
@@ -2,30 +2,30 @@
 
 namespace ConvenientInventory
 {
-	public class ModConfig
-	{
-		public bool IsEnableQuickStack { get; set; } = true;
+    public class ModConfig
+    {
+        public bool IsEnableQuickStack { get; set; } = true;
 
-		public int QuickStackRange { get; set; } = 5;
+        public int QuickStackRange { get; set; } = 5;
 
-		public bool IsQuickStackIntoBuildingsWithInventories { get; set; } = true;
+        public bool IsQuickStackIntoBuildingsWithInventories { get; set; } = true;
 
-		public bool IsQuickStackOverflowItems { get; set; } = true;
+        public bool IsQuickStackOverflowItems { get; set; } = true;
 
-		public bool IsQuickStackTooltipDrawNearbyChests { get; set; } = true;
+        public bool IsQuickStackTooltipDrawNearbyChests { get; set; } = true;
 
-		public bool IsEnableQuickStackHotkey { get; set; } = false;
+        public bool IsEnableQuickStackHotkey { get; set; } = false;
 
-		public SButton QuickStackKeyboardHotkey { get; set; } = SButton.K;
+        public SButton QuickStackKeyboardHotkey { get; set; } = SButton.K;
 
-		public SButton QuickStackControllerHotkey { get; set; } = SButton.LeftStick;
+        public SButton QuickStackControllerHotkey { get; set; } = SButton.LeftStick;
 
-		public bool IsEnableFavoriteItems { get; set; } = true;
+        public bool IsEnableFavoriteItems { get; set; } = true;
 
-		public int FavoriteItemsHighlightTextureChoice { get; set; } = 2;
+        public int FavoriteItemsHighlightTextureChoice { get; set; } = 2;
 
-		public SButton FavoriteItemsKeyboardHotkey { get; set; } = SButton.LeftAlt;
+        public SButton FavoriteItemsKeyboardHotkey { get; set; } = SButton.LeftAlt;
 
-		public SButton FavoriteItemsControllerHotkey { get; set; } = SButton.LeftShoulder;
-	}
+        public SButton FavoriteItemsControllerHotkey { get; set; } = SButton.LeftShoulder;
+    }
 }

--- a/ConvenientInventory/ConvenientInventory/ModEntry.cs
+++ b/ConvenientInventory/ConvenientInventory/ModEntry.cs
@@ -12,7 +12,7 @@ namespace ConvenientInventory
 	/// <summary>The mod entry class loaded by SMAPI.</summary>
 	public class ModEntry : Mod
 	{
-		public static ModEntry Context { get; private set; }
+		public static ModEntry Instance { get; private set; }
 
 		public static ModConfig Config { get; private set; }
 
@@ -20,7 +20,7 @@ namespace ConvenientInventory
 		/// <param name="helper">Provides simplified APIs for writing mods.</param>
 		public override void Entry(IModHelper helper)
 		{
-			Context = this;
+			Instance = this;
 			Config = helper.ReadConfig<ModConfig>();
 
 			ConvenientInventory.QuickStackButtonIcon = helper.Content.Load<Texture2D>(@"assets\icon.png");
@@ -83,15 +83,20 @@ namespace ConvenientInventory
 		private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
 		{
 			// Handle favorite items hotkey being pressed
-			if (Config.IsEnableFavoriteItems && (e.Button == Config.FavoriteItemsKeyboardHotkey || e.Button == Config.FavoriteItemsControllerHotkey))
+			if (Config.IsEnableFavoriteItems
+				&& Context.IsWorldReady
+				&& (e.Button == Config.FavoriteItemsKeyboardHotkey || e.Button == Config.FavoriteItemsControllerHotkey))
             {
 				ConvenientInventory.IsFavoriteItemsHotkeyDown = true;
             }
 
 			// Handle quick stack hotkey being pressed
-			if (Config.IsEnableQuickStackHotkey && (e.Button == Config.QuickStackKeyboardHotkey || e.Button == Config.QuickStackControllerHotkey))
+			if (Config.IsEnableQuickStackHotkey
+				&& Context.IsWorldReady
+				&& StardewValley.Game1.CurrentEvent is null
+				&& (e.Button == Config.QuickStackKeyboardHotkey || e.Button == Config.QuickStackControllerHotkey))
             {
-				ConvenientInventory.QuickStackHotkeyPressed();
+				ConvenientInventory.OnQuickStackHotkeyPressed();
 			}
 		}
 

--- a/ConvenientInventory/ConvenientInventory/ModEntry.cs
+++ b/ConvenientInventory/ConvenientInventory/ModEntry.cs
@@ -9,104 +9,104 @@ using ConvenientInventory.Compatibility;
 
 namespace ConvenientInventory
 {
-	/// <summary>The mod entry class loaded by SMAPI.</summary>
-	public class ModEntry : Mod
-	{
-		public static ModEntry Instance { get; private set; }
+    /// <summary>The mod entry class loaded by SMAPI.</summary>
+    public class ModEntry : Mod
+    {
+        public static ModEntry Instance { get; private set; }
 
-		public static ModConfig Config { get; set; }
+        public static ModConfig Config { get; set; }
 
-		/// <summary>The mod entry point, called after the mod is first loaded.</summary>
-		/// <param name="helper">Provides simplified APIs for writing mods.</param>
-		public override void Entry(IModHelper helper)
-		{
-			Instance = this;
-			Config = helper.ReadConfig<ModConfig>();
-
-			ConvenientInventory.QuickStackButtonIcon = helper.Content.Load<Texture2D>(@"assets\icon.png");
-			ConvenientInventory.FavoriteItemsCursorTexture = helper.Content.Load<Texture2D>(@"assets\favoriteCursor.png");
-			ConvenientInventory.FavoriteItemsHighlightTexture = helper.Content.Load<Texture2D>($@"assets\favoriteHighlight_{Config.FavoriteItemsHighlightTextureChoice}.png");
-			ConvenientInventory.FavoriteItemsBorderTexture = helper.Content.Load<Texture2D>(@"assets\favoriteBorder.png");
-
-			helper.Events.GameLoop.GameLaunched += OnGameLaunched;
-
-			helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
-			helper.Events.GameLoop.Saving += OnSaving;
-
-			helper.Events.Input.ButtonPressed += OnButtonPressed;
-			helper.Events.Input.ButtonReleased += OnButtonReleased;
-		}
-
-		/// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves).
-		/// All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
-		/// <param name="sender">The event sender.</param>
-		/// <param name="e">The event data.</param>
-		private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
-		{
-			var harmony = new Harmony(ModManifest.UniqueID);
-
-			// Manually patch InventoryPage constructor, otherwise Harmony cannot find method.
-			harmony.Patch(
-				original: AccessTools.Constructor(typeof(StardewValley.Menus.InventoryPage), new Type[] { typeof(int), typeof(int), typeof(int), typeof(int) }),
-				postfix: new HarmonyMethod(typeof(InventoryPageConstructorPatch), nameof(InventoryPageConstructorPatch.Postfix))
-			);
-
-			harmony.PatchAll();
-
-			// Initialize mod(s)
-			ModInitializer modInitializer = new(ModManifest, Helper);
-
-			// Get Generic Mod Config Menu API (if it's installed)
-			var api = Helper.ModRegistry.GetApi<IGenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
-			if (api != null)
-			{
-				modInitializer.Initialize(api, Config);
-			}
-		}
-
-		private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
-		{
-			if (Config.IsEnableFavoriteItems)
-			{
-				ConvenientInventory.LoadFavoriteItemSlots();
-			}
-		}
-
-		private void OnSaving(object sender, SavingEventArgs e)
+        /// <summary>The mod entry point, called after the mod is first loaded.</summary>
+        /// <param name="helper">Provides simplified APIs for writing mods.</param>
+        public override void Entry(IModHelper helper)
         {
-			if (Config.IsEnableFavoriteItems)
-			{
-				ConvenientInventory.SaveFavoriteItemSlots();
-			}
+            Instance = this;
+            Config = helper.ReadConfig<ModConfig>();
+
+            ConvenientInventory.QuickStackButtonIcon = helper.Content.Load<Texture2D>(@"assets\icon.png");
+            ConvenientInventory.FavoriteItemsCursorTexture = helper.Content.Load<Texture2D>(@"assets\favoriteCursor.png");
+            ConvenientInventory.FavoriteItemsHighlightTexture = helper.Content.Load<Texture2D>($@"assets\favoriteHighlight_{Config.FavoriteItemsHighlightTextureChoice}.png");
+            ConvenientInventory.FavoriteItemsBorderTexture = helper.Content.Load<Texture2D>(@"assets\favoriteBorder.png");
+
+            helper.Events.GameLoop.GameLaunched += OnGameLaunched;
+
+            helper.Events.GameLoop.SaveLoaded += OnSaveLoaded;
+            helper.Events.GameLoop.Saving += OnSaving;
+
+            helper.Events.Input.ButtonPressed += OnButtonPressed;
+            helper.Events.Input.ButtonReleased += OnButtonReleased;
         }
 
-		private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
-		{
-			// Handle favorite items hotkey being pressed
-			if (Config.IsEnableFavoriteItems
-				&& Context.IsWorldReady
-				&& (e.Button == Config.FavoriteItemsKeyboardHotkey || e.Button == Config.FavoriteItemsControllerHotkey))
+        /// <summary>Raised after the game is launched, right before the first update tick. This happens once per game session (unrelated to loading saves).
+        /// All mods are loaded and initialised at this point, so this is a good time to set up mod integrations.</summary>
+        /// <param name="sender">The event sender.</param>
+        /// <param name="e">The event data.</param>
+        private void OnGameLaunched(object sender, GameLaunchedEventArgs e)
+        {
+            var harmony = new Harmony(ModManifest.UniqueID);
+
+            // Manually patch InventoryPage constructor, otherwise Harmony cannot find method.
+            harmony.Patch(
+                original: AccessTools.Constructor(typeof(StardewValley.Menus.InventoryPage), new Type[] { typeof(int), typeof(int), typeof(int), typeof(int) }),
+                postfix: new HarmonyMethod(typeof(InventoryPageConstructorPatch), nameof(InventoryPageConstructorPatch.Postfix))
+            );
+
+            harmony.PatchAll();
+
+            // Initialize mod(s)
+            ModInitializer modInitializer = new(ModManifest, Helper);
+
+            // Get Generic Mod Config Menu API (if it's installed)
+            var api = Helper.ModRegistry.GetApi<IGenericModConfigMenuApi>("spacechase0.GenericModConfigMenu");
+            if (api != null)
             {
-				ConvenientInventory.IsFavoriteItemsHotkeyDown = true;
+                modInitializer.Initialize(api, Config);
+            }
+        }
+
+        private void OnSaveLoaded(object sender, SaveLoadedEventArgs e)
+        {
+            if (Config.IsEnableFavoriteItems)
+            {
+                ConvenientInventory.LoadFavoriteItemSlots();
+            }
+        }
+
+        private void OnSaving(object sender, SavingEventArgs e)
+        {
+            if (Config.IsEnableFavoriteItems)
+            {
+                ConvenientInventory.SaveFavoriteItemSlots();
+            }
+        }
+
+        private void OnButtonPressed(object sender, ButtonPressedEventArgs e)
+        {
+            // Handle favorite items hotkey being pressed
+            if (Config.IsEnableFavoriteItems
+                && Context.IsWorldReady
+                && (e.Button == Config.FavoriteItemsKeyboardHotkey || e.Button == Config.FavoriteItemsControllerHotkey))
+            {
+                ConvenientInventory.IsFavoriteItemsHotkeyDown = true;
             }
 
-			// Handle quick stack hotkey being pressed
-			if (Config.IsEnableQuickStackHotkey
-				&& Context.IsWorldReady
-				&& StardewValley.Game1.CurrentEvent is null
-				&& (e.Button == Config.QuickStackKeyboardHotkey || e.Button == Config.QuickStackControllerHotkey))
+            // Handle quick stack hotkey being pressed
+            if (Config.IsEnableQuickStackHotkey
+                && Context.IsWorldReady
+                && StardewValley.Game1.CurrentEvent is null
+                && (e.Button == Config.QuickStackKeyboardHotkey || e.Button == Config.QuickStackControllerHotkey))
             {
-				ConvenientInventory.OnQuickStackHotkeyPressed();
-			}
-		}
+                ConvenientInventory.OnQuickStackHotkeyPressed();
+            }
+        }
 
-		private void OnButtonReleased(object sender, ButtonReleasedEventArgs e)
-		{
-			// Handle favorite items hotkey being released
-			if (Config.IsEnableFavoriteItems && (e.Button == Config.FavoriteItemsKeyboardHotkey || e.Button == Config.FavoriteItemsControllerHotkey))
-			{
-				ConvenientInventory.IsFavoriteItemsHotkeyDown = false;
-			}
-		}
-	}
+        private void OnButtonReleased(object sender, ButtonReleasedEventArgs e)
+        {
+            // Handle favorite items hotkey being released
+            if (Config.IsEnableFavoriteItems && (e.Button == Config.FavoriteItemsKeyboardHotkey || e.Button == Config.FavoriteItemsControllerHotkey))
+            {
+                ConvenientInventory.IsFavoriteItemsHotkeyDown = false;
+            }
+        }
+    }
 }

--- a/ConvenientInventory/ConvenientInventory/ModEntry.cs
+++ b/ConvenientInventory/ConvenientInventory/ModEntry.cs
@@ -14,7 +14,7 @@ namespace ConvenientInventory
 	{
 		public static ModEntry Instance { get; private set; }
 
-		public static ModConfig Config { get; private set; }
+		public static ModConfig Config { get; set; }
 
 		/// <summary>The mod entry point, called after the mod is first loaded.</summary>
 		/// <param name="helper">Provides simplified APIs for writing mods.</param>

--- a/ConvenientInventory/ConvenientInventory/ModEntry.cs
+++ b/ConvenientInventory/ConvenientInventory/ModEntry.cs
@@ -78,6 +78,7 @@ namespace ConvenientInventory
 					optionGet: () => Config.IsEnableQuickStack,
 					optionSet: value => Config.IsEnableQuickStack = value
 				);
+
 				api.RegisterClampedOption(
 					mod: ModManifest,
 					optionName: "Range",
@@ -88,6 +89,7 @@ namespace ConvenientInventory
 					max: 10,
 					interval: 1
 				);
+
 				api.RegisterSimpleOption(
 					mod: ModManifest,
 					optionName: "Quick stack into buildings?",
@@ -95,6 +97,7 @@ namespace ConvenientInventory
 					optionGet: () => Config.IsQuickStackIntoBuildingsWithInventories,
 					optionSet: value => Config.IsQuickStackIntoBuildingsWithInventories = value
 				);
+
 				api.RegisterSimpleOption(
 					mod: ModManifest,
 					optionName: "Quick stack overflow items?",
@@ -102,6 +105,7 @@ namespace ConvenientInventory
 					optionGet: () => Config.IsQuickStackOverflowItems,
 					optionSet: value => Config.IsQuickStackOverflowItems = value
 				);
+
 				api.RegisterSimpleOption(
 					mod: ModManifest,
 					optionName: "Show nearby chests in tooltip?",
@@ -115,6 +119,7 @@ namespace ConvenientInventory
 					labelName: "Favorite Items",
 					labelDesc: null
 				);
+
 				api.RegisterSimpleOption(
 					mod: ModManifest,
 					optionName: "Enable favorite items?",   // TODO: Will favorited items ignore Add To Existing Stacks? Or just quick stack?
@@ -122,35 +127,29 @@ namespace ConvenientInventory
 					optionGet: () => Config.IsEnableFavoriteItems,
 					optionSet: value => Config.IsEnableFavoriteItems = value
 				);
+
 				string[] highlightStyleDescriptions =
 				{
-					": Gold dashed",
-					": Clean gold dashed",
-					": Thick gold border",
-					": Textured gold inset border",
-					": Gold inset border",
-					": Dark dashed"
+					"0: Gold dashed",
+					"1: Clean gold dashed",
+					"2: Thick gold border",
+					"3: Textured gold inset border",
+					"4: Gold inset border",
+					"5: Dark dashed"
 				};
 				api.RegisterChoiceOption(
 					mod: ModManifest,
 					optionName: "Highlight style",
 					optionDesc: "Choose your preferred texture style for highlighting favorited items in your inventory.",
-					optionGet: () => Config.FavoriteItemsHighlightTextureChoice.ToString() + highlightStyleDescriptions[Config.FavoriteItemsHighlightTextureChoice],
+					optionGet: () => highlightStyleDescriptions[Config.FavoriteItemsHighlightTextureChoice],
 					optionSet: value =>
 					{
 						Config.FavoriteItemsHighlightTextureChoice = int.Parse(value.Substring(0, 1));
 						ConvenientInventory.FavoriteItemsHighlightTexture = Helper.Content.Load<Texture2D>($@"Assets\favoriteHighlight_{value[0]}.png");
 					},
-					choices: new string[]
-					{
-						"0" + highlightStyleDescriptions[0],
-						"1" + highlightStyleDescriptions[1],
-						"2" + highlightStyleDescriptions[2],
-						"3" + highlightStyleDescriptions[3],
-						"4" + highlightStyleDescriptions[4],
-						"5" + highlightStyleDescriptions[5]
-					}
+					choices: highlightStyleDescriptions
 				);
+
 				api.RegisterSimpleOption(
 					mod: ModManifest,
 					optionName: "Keybind (keyboard)",
@@ -158,6 +157,7 @@ namespace ConvenientInventory
 					optionGet: () => Config.FavoriteItemsKeyboardHotkey,
 					optionSet: value => Config.FavoriteItemsKeyboardHotkey = value
 				);
+
 				api.RegisterSimpleOption(
 					mod: ModManifest,
 					optionName: "Keybind (controller)",

--- a/ConvenientInventory/ConvenientInventory/Patches.cs
+++ b/ConvenientInventory/ConvenientInventory/Patches.cs
@@ -139,6 +139,7 @@ namespace ConvenientInventory.Patches
 			return true;
 		}
 
+		/*
 		[HarmonyPostfix]
 		[HarmonyPatch(nameof(CraftingPage.receiveLeftClick))]
 		public static void ReceiveLeftClick_Postfix(CraftingPage __instance, int x, int y)
@@ -152,6 +153,7 @@ namespace ConvenientInventory.Patches
 				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
+		*/
 
 		[HarmonyPrefix]
 		[HarmonyPatch(nameof(CraftingPage.receiveRightClick))]
@@ -312,6 +314,7 @@ namespace ConvenientInventory.Patches
 			return true;
 		}
 
+		/*
 		[HarmonyPostfix]
 		[HarmonyPatch(nameof(MenuWithInventory.receiveLeftClick))]
 		public static void ReceiveLeftClick_Postfix(MenuWithInventory __instance, int x, int y)
@@ -325,6 +328,7 @@ namespace ConvenientInventory.Patches
 				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
+		*/
 
 		[HarmonyPrefix]
 		[HarmonyPatch(nameof(MenuWithInventory.receiveRightClick))]

--- a/ConvenientInventory/ConvenientInventory/Patches.cs
+++ b/ConvenientInventory/ConvenientInventory/Patches.cs
@@ -23,7 +23,7 @@ namespace ConvenientInventory.Patches
             }
             catch (Exception e)
             {
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 	}
@@ -41,7 +41,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 
@@ -55,7 +55,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(PerformHoverAction_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(PerformHoverAction_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 
@@ -69,7 +69,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
 			}
 
 			return true;
@@ -85,7 +85,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 
@@ -99,7 +99,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
 			}
 
 			return true;
@@ -119,7 +119,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 
@@ -133,7 +133,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
 			}
 
 			return true;
@@ -165,7 +165,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
 			}
 
 			return true;
@@ -188,7 +188,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(PopulateClickableComponentsList_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(PopulateClickableComponentsList_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 
@@ -205,7 +205,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(Update_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Update_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 
@@ -251,7 +251,7 @@ namespace ConvenientInventory.Patches
 
 			if (!flag)
 			{
-				ModEntry.Context.Monitor.Log(
+				ModEntry.Instance.Monitor.Log(
 					$"{nameof(DrawHoverText_Transpiler)} could not find target instruction(s) in {nameof(IClickableMenu.drawHoverText)}, so no changes were made.", LogLevel.Error);
 			}
 
@@ -275,7 +275,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 	}
@@ -294,7 +294,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 
@@ -308,7 +308,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
 			}
 
 			return true;
@@ -340,7 +340,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
 			}
 
 			return true;
@@ -396,7 +396,7 @@ namespace ConvenientInventory.Patches
 
 			if (!flag)
 			{
-				ModEntry.Context.Monitor.Log(
+				ModEntry.Instance.Monitor.Log(
 					$"{nameof(InventoryMenuPatches)}.{nameof(Draw_Transpiler)} could not find target instruction(s) in {nameof(InventoryMenu.draw)}, so no changes were made.", LogLevel.Error);
 			}
 
@@ -420,7 +420,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 	}
@@ -481,7 +481,7 @@ namespace ConvenientInventory.Patches
 
 			if (!flag)
 			{
-				ModEntry.Context.Monitor.Log(
+				ModEntry.Instance.Monitor.Log(
 					$"{nameof(ToolbarPatches)}.{nameof(Draw_Transpiler)} could not find target instruction(s) in {nameof(Toolbar.draw)}, so no changes were made.", LogLevel.Error);
 			}
 
@@ -504,7 +504,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 
@@ -518,7 +518,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
 			}
 
 			return true;
@@ -534,7 +534,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
 			}
 
 			return true;
@@ -565,7 +565,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(OrganizeItemsInList_Prefix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(OrganizeItemsInList_Prefix)}:\n{e}", LogLevel.Error);
 			}
 
 			return true;
@@ -590,7 +590,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(OrganizeItemsInList_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(OrganizeItemsInList_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 
@@ -611,7 +611,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(FillOutStacks_Prefix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(FillOutStacks_Prefix)}:\n{e}", LogLevel.Error);
 			}
 
 			return true;
@@ -632,7 +632,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(FillOutStacks_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(FillOutStacks_Postfix)}:\n{e}", LogLevel.Error);
 			}
 		}
 	}
@@ -681,7 +681,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
             {
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(ShiftToolbar_Postfix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ShiftToolbar_Postfix)}:\n{e}", LogLevel.Error);
             }
         }
 
@@ -700,7 +700,7 @@ namespace ConvenientInventory.Patches
 			}
 			catch (Exception e)
 			{
-				ModEntry.Context.Monitor.Log($"Failed in {nameof(ReduceActiveItemByOne_Prefix)}:\n{e}", LogLevel.Error);
+				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReduceActiveItemByOne_Prefix)}:\n{e}", LogLevel.Error);
 			}
 
 			return true;

--- a/ConvenientInventory/ConvenientInventory/Patches.cs
+++ b/ConvenientInventory/ConvenientInventory/Patches.cs
@@ -13,133 +13,133 @@ using System.Text;
 
 namespace ConvenientInventory.Patches
 {
-	public class InventoryPageConstructorPatch
-	{
-		public static void Postfix(InventoryPage __instance, int x, int y, int width, int height)
-		{
+    public class InventoryPageConstructorPatch
+    {
+        public static void Postfix(InventoryPage __instance, int x, int y, int width, int height)
+        {
             try
             {
                 ConvenientInventory.InventoryPageConstructor(__instance, x, y, width, height);
             }
             catch (Exception e)
             {
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
-	}
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
+    }
 
-	[HarmonyPatch(typeof(InventoryPage))]
-	public class InventoryPagePatches
-	{
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(InventoryPage.draw))]
-		public static void Draw_Postfix(InventoryPage __instance, SpriteBatch b)
-		{
-			try
+    [HarmonyPatch(typeof(InventoryPage))]
+    public class InventoryPagePatches
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(InventoryPage.draw))]
+        public static void Draw_Postfix(InventoryPage __instance, SpriteBatch b)
+        {
+            try
             {
                 ConvenientInventory.PostMenuDraw(__instance, b);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
 
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(InventoryPage.performHoverAction))]
-		public static void PerformHoverAction_Postfix(int x, int y)
-		{
-			try
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(InventoryPage.performHoverAction))]
+        public static void PerformHoverAction_Postfix(int x, int y)
+        {
+            try
             {
                 ConvenientInventory.PerformHoverActionInInventoryPage(x, y);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(PerformHoverAction_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(PerformHoverAction_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
 
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(InventoryPage.receiveLeftClick))]
-		public static bool ReceiveLeftClick_Prefix(InventoryPage __instance, int x, int y)
-		{
-			try
-			{
-				return ConvenientInventory.PreReceiveLeftClickInMenu(__instance, x, y);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
-			}
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(InventoryPage.receiveLeftClick))]
+        public static bool ReceiveLeftClick_Prefix(InventoryPage __instance, int x, int y)
+        {
+            try
+            {
+                return ConvenientInventory.PreReceiveLeftClickInMenu(__instance, x, y);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
+            }
 
-			return true;
-		}
+            return true;
+        }
 
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(InventoryPage.receiveLeftClick))]
-		public static void ReceiveLeftClick_Postfix(InventoryPage __instance, int x, int y)
-		{
-			try
-			{
-				ConvenientInventory.PostReceiveLeftClickInMenu(__instance, x, y);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(InventoryPage.receiveLeftClick))]
+        public static void ReceiveLeftClick_Postfix(InventoryPage __instance, int x, int y)
+        {
+            try
+            {
+                ConvenientInventory.PostReceiveLeftClickInMenu(__instance, x, y);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
 
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(InventoryPage.receiveRightClick))]
-		public static bool ReceiveRightClick_Prefix(InventoryPage __instance, int x, int y)
-		{
-			try
-			{
-				return ConvenientInventory.PreReceiveRightClickInMenu(__instance, x, y);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
-			}
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(InventoryPage.receiveRightClick))]
+        public static bool ReceiveRightClick_Prefix(InventoryPage __instance, int x, int y)
+        {
+            try
+            {
+                return ConvenientInventory.PreReceiveRightClickInMenu(__instance, x, y);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
+            }
 
-			return true;
-		}
-	}
+            return true;
+        }
+    }
 
-	[HarmonyPatch(typeof(CraftingPage))]
-	public class CraftingPagePatches
-	{
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(CraftingPage.draw))]
-		public static void Draw_Postfix(CraftingPage __instance, SpriteBatch b)
-		{
-			try
-			{
-				ConvenientInventory.PostMenuDraw(__instance, b);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
+    [HarmonyPatch(typeof(CraftingPage))]
+    public class CraftingPagePatches
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(CraftingPage.draw))]
+        public static void Draw_Postfix(CraftingPage __instance, SpriteBatch b)
+        {
+            try
+            {
+                ConvenientInventory.PostMenuDraw(__instance, b);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
 
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(CraftingPage.receiveLeftClick))]
-		public static bool ReceiveLeftClick_Prefix(CraftingPage __instance, int x, int y)
-		{
-			try
-			{
-				return ConvenientInventory.PreReceiveLeftClickInMenu(__instance, x, y);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
-			}
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(CraftingPage.receiveLeftClick))]
+        public static bool ReceiveLeftClick_Prefix(CraftingPage __instance, int x, int y)
+        {
+            try
+            {
+                return ConvenientInventory.PreReceiveLeftClickInMenu(__instance, x, y);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
+            }
 
-			return true;
-		}
+            return true;
+        }
 
-		/*
+        /*
 		[HarmonyPostfix]
 		[HarmonyPatch(nameof(CraftingPage.receiveLeftClick))]
 		public static void ReceiveLeftClick_Postfix(CraftingPage __instance, int x, int y)
@@ -155,166 +155,166 @@ namespace ConvenientInventory.Patches
 		}
 		*/
 
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(CraftingPage.receiveRightClick))]
-		public static bool ReceiveRightClick_Prefix(CraftingPage __instance, int x, int y)
-		{
-			try
-			{
-				return ConvenientInventory.PreReceiveRightClickInMenu(__instance, x, y);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
-			}
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(CraftingPage.receiveRightClick))]
+        public static bool ReceiveRightClick_Prefix(CraftingPage __instance, int x, int y)
+        {
+            try
+            {
+                return ConvenientInventory.PreReceiveRightClickInMenu(__instance, x, y);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
+            }
 
-			return true;
-		}
-	}
+            return true;
+        }
+    }
 
-	[HarmonyPatch(typeof(IClickableMenu))]
-	public class IClickableMenuPatches
-	{
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(IClickableMenu.populateClickableComponentList))]
-		public static void PopulateClickableComponentsList_Postfix(IClickableMenu __instance)
-		{
-			try
-			{
-				if (__instance is InventoryPage inventoryPage)
-				{
-					ConvenientInventory.PopulateClickableComponentsListInInventoryPage(inventoryPage);
-				}
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(PopulateClickableComponentsList_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
+    [HarmonyPatch(typeof(IClickableMenu))]
+    public class IClickableMenuPatches
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(IClickableMenu.populateClickableComponentList))]
+        public static void PopulateClickableComponentsList_Postfix(IClickableMenu __instance)
+        {
+            try
+            {
+                if (__instance is InventoryPage inventoryPage)
+                {
+                    ConvenientInventory.PopulateClickableComponentsListInInventoryPage(inventoryPage);
+                }
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(PopulateClickableComponentsList_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
 
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(IClickableMenu.update))]
-		public static void Update_Postfix(IClickableMenu __instance, GameTime time)
-		{
-			try
-			{
-				if (__instance is InventoryPage inventoryPage)
-				{
-					ConvenientInventory.Update(time);
-				}
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Update_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(IClickableMenu.update))]
+        public static void Update_Postfix(IClickableMenu __instance, GameTime time)
+        {
+            try
+            {
+                if (__instance is InventoryPage inventoryPage)
+                {
+                    ConvenientInventory.Update(time);
+                }
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(Update_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
 
-		[HarmonyTranspiler]
-		[HarmonyPatch(nameof(IClickableMenu.drawHoverText))]
-		[HarmonyPatch(new Type[]
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(IClickableMenu.drawHoverText))]
+        [HarmonyPatch(new Type[]
         {
             typeof(SpriteBatch), typeof(StringBuilder), typeof(SpriteFont), typeof(int), typeof(int),
             typeof(int), typeof(string), typeof(int), typeof(string[]), typeof(Item), typeof(int), typeof(int), typeof(int), typeof(int),
             typeof(int), typeof(float), typeof(CraftingRecipe), typeof(IList<Item>)
         })]
-		public static IEnumerable<CodeInstruction> DrawHoverText_Transpiler(IEnumerable<CodeInstruction> instructions)
-		{
-			MethodInfo getYMinusBoldTitleTextHeight = AccessTools.Method(typeof(IClickableMenuPatches), nameof(GetYMinusBoldTitleTextHeight));
-			MethodInfo drawFavoriteItemsToolTipBorder = AccessTools.Method(typeof(ConvenientInventory), nameof(ConvenientInventory.DrawFavoriteItemsToolTipBorder));
+        public static IEnumerable<CodeInstruction> DrawHoverText_Transpiler(IEnumerable<CodeInstruction> instructions)
+        {
+            MethodInfo getYMinusBoldTitleTextHeight = AccessTools.Method(typeof(IClickableMenuPatches), nameof(GetYMinusBoldTitleTextHeight));
+            MethodInfo drawFavoriteItemsToolTipBorder = AccessTools.Method(typeof(ConvenientInventory), nameof(ConvenientInventory.DrawFavoriteItemsToolTipBorder));
 
-			List<CodeInstruction> instructionsList = instructions.ToList();
+            List<CodeInstruction> instructionsList = instructions.ToList();
 
-			bool flag = false;
+            bool flag = false;
 
-			for (int i = 0; i<instructionsList.Count; i++)
-			{
-				// Find instruction after if(boldTitleText != null){} block
-				// IL_07b3 (instructionsList[772])
-				if (i > 0 && i < instructionsList.Count - 1
-					&& instructionsList[i - 1].opcode == OpCodes.Stloc_S && (instructionsList[i - 1].operand as LocalBuilder)?.LocalIndex == 6
-					&& instructionsList[i].opcode == OpCodes.Ldarg_S && instructionsList[i].operand is byte b && b == 9
-					&& instructionsList[i + 1].opcode == OpCodes.Brfalse)
-				{
-					yield return new CodeInstruction(OpCodes.Ldarg, 9);                              // load Item "hoveredItem" (arg 9)
-					yield return new CodeInstruction(OpCodes.Ldarg_0);                               // load SpriteBatch "b" (arg 1)
-					yield return new CodeInstruction(OpCodes.Ldloc_S, 5);                            // load local int "x"
-					yield return new CodeInstruction(OpCodes.Ldloc_S, 6);                            //     load local int "y"
-					yield return new CodeInstruction(OpCodes.Ldarg, 6);                              //     load string "boldTitleText" (arg 6)
-					yield return new CodeInstruction(OpCodes.Call, getYMinusBoldTitleTextHeight);    //     call GetYMinusBoldTitleTextHeight(y, boldTitleText)
-					yield return new CodeInstruction(OpCodes.Call, drawFavoriteItemsToolTipBorder);  // call DrawFavoriteItemsToolTipBorder(hoveredItem, b, x, GetYMinus)
+            for (int i = 0; i < instructionsList.Count; i++)
+            {
+                // Find instruction after if(boldTitleText != null){} block
+                // IL_07b3 (instructionsList[772])
+                if (i > 0 && i < instructionsList.Count - 1
+                    && instructionsList[i - 1].opcode == OpCodes.Stloc_S && (instructionsList[i - 1].operand as LocalBuilder)?.LocalIndex == 6
+                    && instructionsList[i].opcode == OpCodes.Ldarg_S && instructionsList[i].operand is byte b && b == 9
+                    && instructionsList[i + 1].opcode == OpCodes.Brfalse)
+                {
+                    yield return new CodeInstruction(OpCodes.Ldarg, 9);                              // load Item "hoveredItem" (arg 9)
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);                               // load SpriteBatch "b" (arg 1)
+                    yield return new CodeInstruction(OpCodes.Ldloc_S, 5);                            // load local int "x"
+                    yield return new CodeInstruction(OpCodes.Ldloc_S, 6);                            //     load local int "y"
+                    yield return new CodeInstruction(OpCodes.Ldarg, 6);                              //     load string "boldTitleText" (arg 6)
+                    yield return new CodeInstruction(OpCodes.Call, getYMinusBoldTitleTextHeight);    //     call GetYMinusBoldTitleTextHeight(y, boldTitleText)
+                    yield return new CodeInstruction(OpCodes.Call, drawFavoriteItemsToolTipBorder);  // call DrawFavoriteItemsToolTipBorder(hoveredItem, b, x, GetYMinus)
 
-					flag = true;
-				}
+                    flag = true;
+                }
 
-				yield return instructionsList[i];
-			}
+                yield return instructionsList[i];
+            }
 
-			if (!flag)
-			{
-				ModEntry.Instance.Monitor.Log(
-					$"{nameof(DrawHoverText_Transpiler)} could not find target instruction(s) in {nameof(IClickableMenu.drawHoverText)}, so no changes were made.", LogLevel.Error);
-			}
+            if (!flag)
+            {
+                ModEntry.Instance.Monitor.Log(
+                    $"{nameof(DrawHoverText_Transpiler)} could not find target instruction(s) in {nameof(IClickableMenu.drawHoverText)}, so no changes were made.", LogLevel.Error);
+            }
 
-			yield break;
-		}
+            yield break;
+        }
 
-		public static int GetYMinusBoldTitleTextHeight(int y, string boldTitleText) => (boldTitleText is null) ? y : (y - (int)Game1.dialogueFont.MeasureString(boldTitleText).Y);
-	}
+        public static int GetYMinusBoldTitleTextHeight(int y, string boldTitleText) => (boldTitleText is null) ? y : (y - (int)Game1.dialogueFont.MeasureString(boldTitleText).Y);
+    }
 
-	[HarmonyPatch(typeof(ClickableTextureComponent))]
-	public class ClickableTextureComponentPatches
-	{
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(ClickableTextureComponent.draw))]
-		[HarmonyPatch(new Type[] { typeof(SpriteBatch) })]
-		public static void Draw_Postfix(ClickableTextureComponent __instance, SpriteBatch b)
-		{
-			try
-			{
-				ConvenientInventory.PostClickableTextureComponentDraw(__instance, b);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
-	}
+    [HarmonyPatch(typeof(ClickableTextureComponent))]
+    public class ClickableTextureComponentPatches
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(ClickableTextureComponent.draw))]
+        [HarmonyPatch(new Type[] { typeof(SpriteBatch) })]
+        public static void Draw_Postfix(ClickableTextureComponent __instance, SpriteBatch b)
+        {
+            try
+            {
+                ConvenientInventory.PostClickableTextureComponentDraw(__instance, b);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
+    }
 
-	[HarmonyPatch(typeof(MenuWithInventory))]
-	public class MenuWithInventoryPatches
-	{
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(MenuWithInventory.draw))]
-		[HarmonyPatch(new Type[] { typeof(SpriteBatch), typeof(bool), typeof(bool), typeof(int), typeof(int), typeof(int) })]
-		public static void Draw_Postfix(MenuWithInventory __instance, SpriteBatch b)
-		{
-			try
-			{
-				ConvenientInventory.PostMenuDraw(__instance, b);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
+    [HarmonyPatch(typeof(MenuWithInventory))]
+    public class MenuWithInventoryPatches
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(MenuWithInventory.draw))]
+        [HarmonyPatch(new Type[] { typeof(SpriteBatch), typeof(bool), typeof(bool), typeof(int), typeof(int), typeof(int) })]
+        public static void Draw_Postfix(MenuWithInventory __instance, SpriteBatch b)
+        {
+            try
+            {
+                ConvenientInventory.PostMenuDraw(__instance, b);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
 
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(MenuWithInventory.receiveLeftClick))]
-		public static bool ReceiveLeftClick_Prefix(MenuWithInventory __instance, int x, int y)
-		{
-			try
-			{
-				return ConvenientInventory.PreReceiveLeftClickInMenu(__instance, x, y);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
-			}
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MenuWithInventory.receiveLeftClick))]
+        public static bool ReceiveLeftClick_Prefix(MenuWithInventory __instance, int x, int y)
+        {
+            try
+            {
+                return ConvenientInventory.PreReceiveLeftClickInMenu(__instance, x, y);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
+            }
 
-			return true;
-		}
+            return true;
+        }
 
-		/*
+        /*
 		[HarmonyPostfix]
 		[HarmonyPatch(nameof(MenuWithInventory.receiveLeftClick))]
 		public static void ReceiveLeftClick_Postfix(MenuWithInventory __instance, int x, int y)
@@ -330,380 +330,380 @@ namespace ConvenientInventory.Patches
 		}
 		*/
 
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(MenuWithInventory.receiveRightClick))]
-		public static bool ReceiveRightClick_Prefix(MenuWithInventory __instance, int x, int y)
-		{
-			try
-			{
-				return ConvenientInventory.PreReceiveRightClickInMenu(__instance, x, y);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
-			}
-
-			return true;
-		}
-	}
-
-	[HarmonyPatch(typeof(InventoryMenu))]
-	public class InventoryMenuPatches
-	{
-		[HarmonyTranspiler]
-		[HarmonyPatch(nameof(InventoryMenu.draw))]
-		[HarmonyPatch(new Type[] { typeof(SpriteBatch), typeof(int), typeof(int), typeof(int) })]
-		public static IEnumerable<CodeInstruction> Draw_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator ilg)
-		{
-			MethodInfo isPlayerInventory = AccessTools.Method(typeof(ConvenientInventory), nameof(ConvenientInventory.IsPlayerInventory));
-			MethodInfo drawFavoriteItemSlotHighlights = AccessTools.Method(typeof(ConvenientInventory), nameof(ConvenientInventory.DrawFavoriteItemSlotHighlights));
-
-			MethodInfo isConfigEnableFavoriteItems = AccessTools.Method(typeof(InventoryMenuPatches), nameof(InventoryMenuPatches.IsConfigEnableFavoriteItems));
-
-			List<CodeInstruction> instructionsList = instructions.ToList();
-
-			bool flag = false;
-
-			for (int i = 0; i < instructionsList.Count; i++)
-			{
-				// Find instruction at start of (int k = 0; k < this.capacity; k++){} block
-				// IL_02d0 (instructionsList[?])
-				if (i < instructionsList.Count - 2
-					&& instructionsList[i].opcode == OpCodes.Ldc_I4_0
-					&& instructionsList[i + 1].opcode == OpCodes.Stloc_S && (instructionsList[i + 1].operand as LocalBuilder)?.LocalIndex == 9
-					&& instructionsList[i + 2].opcode == OpCodes.Br)
-				{
-					Label label = ilg.DefineLabel();
-
-					yield return new CodeInstruction(OpCodes.Ldarg_0) { labels = instructionsList[i].ExtractLabels() };	// load this InventoryMenu instance (arg 0)
-					yield return new CodeInstruction(OpCodes.Call, isPlayerInventory);									// call IsPlayerInventory(this)
-					yield return new CodeInstruction(OpCodes.Brfalse, label);                                           // break if call => false
-
-					yield return new CodeInstruction(OpCodes.Call, isConfigEnableFavoriteItems);                        // call helper method
-					yield return new CodeInstruction(OpCodes.Brfalse, label);                                           // break if call => false
-
-					yield return new CodeInstruction(OpCodes.Ldarg_1);													// load SpriteBatch "b" (arg 1)
-					yield return new CodeInstruction(OpCodes.Ldarg_0);													// load this InventoryMenu instance (arg 0)
-					yield return new CodeInstruction(OpCodes.Call, drawFavoriteItemSlotHighlights);						// call DrawFavoriteItemSlotHighlights(b, this)
-
-					instructionsList[i].WithLabels(label);
-
-					flag = true;
-				}
-
-				yield return instructionsList[i];
-			}
-
-			if (!flag)
-			{
-				ModEntry.Instance.Monitor.Log(
-					$"{nameof(InventoryMenuPatches)}.{nameof(Draw_Transpiler)} could not find target instruction(s) in {nameof(InventoryMenu.draw)}, so no changes were made.", LogLevel.Error);
-			}
-
-			yield break;
-		}
-
-		public static bool IsConfigEnableFavoriteItems() => ModEntry.Config.IsEnableFavoriteItems;
-
-
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(InventoryMenu.draw))]
-		[HarmonyPatch(new Type[] { typeof(SpriteBatch), typeof(int), typeof(int), typeof(int) })]
-		public static void Draw_Postfix(InventoryMenu __instance, SpriteBatch b)
-		{
-			try
-			{
-				if (ConvenientInventory.IsPlayerInventory(__instance))
-                {
-					ConvenientInventory.PostMenuDraw(__instance, b);
-				}
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
-	}
-
-	[HarmonyPatch(typeof(Toolbar))]
-	public class ToolbarPatches
-	{
-		[HarmonyTranspiler]
-		[HarmonyPatch(nameof(Toolbar.draw))]
-		[HarmonyPatch(new Type[] { typeof(SpriteBatch) })]
-		public static IEnumerable<CodeInstruction> Draw_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator ilg)
-		{
-			MethodInfo isConfigEnableFavoriteItems = AccessTools.Method(typeof(ToolbarPatches), nameof(ToolbarPatches.IsConfigEnableFavoriteItems));
-			MethodInfo DrawFavoriteItemSlotHighlightsInToolbar = AccessTools.Method(typeof(ConvenientInventory), nameof(ConvenientInventory.DrawFavoriteItemSlotHighlightsInToolbar));
-
-			FieldInfo yPositionOnScreen = typeof(Toolbar).GetField("yPositionOnScreen", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-			FieldInfo transparency = typeof(Toolbar).GetField("transparency", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-			FieldInfo slotText = typeof(Toolbar).GetField("slotText", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
-
-			List<CodeInstruction> instructionsList = instructions.ToList();
-
-			bool flag = false;
-
-			for (int i = 0; i < instructionsList.Count; i++)
-			{
-				// Find instruction after for(int j = 0; j < 12; j++){} block
-				// IL_027b (instructionsList[229])
-				if (i > 0 && i < instructionsList.Count - 2
-					&& instructionsList[i - 1].opcode == OpCodes.Blt
-					&& instructionsList[i].opcode == OpCodes.Ldc_I4_0
-					&& instructionsList[i + 1].opcode == OpCodes.Stloc_S && (instructionsList[i + 1].operand as LocalBuilder)?.LocalIndex == 9
-					&& instructionsList[i + 2].opcode == OpCodes.Br)
-				{
-					Label label = ilg.DefineLabel();
-
-					yield return new CodeInstruction(OpCodes.Call, isConfigEnableFavoriteItems)					// call helper method
-					{
-						labels = instructionsList[i].ExtractLabels()
-					};
-					yield return new CodeInstruction(OpCodes.Brfalse, label);                                   // break if call => false
-
-					yield return new CodeInstruction(OpCodes.Ldarg_1);                                          // load SpriteBatch "b" (arg 1)
-					yield return new CodeInstruction(OpCodes.Ldarg_0);                                          // load this (arg0)
-					yield return new CodeInstruction(OpCodes.Ldfld, yPositionOnScreen);                         // load local variable "this.yPositionOnScreen"
-					yield return new CodeInstruction(OpCodes.Ldarg_0);                                          // load this (arg0)
-					yield return new CodeInstruction(OpCodes.Ldfld, transparency);                              // load local variable "this.transparency"
-					yield return new CodeInstruction(OpCodes.Ldarg_0);                                          // load this (arg0)
-					yield return new CodeInstruction(OpCodes.Ldfld, slotText);									// load local variable "this.slotText"
-					yield return new CodeInstruction(OpCodes.Call, DrawFavoriteItemSlotHighlightsInToolbar);	// call DrawFavoriteItemSlotHighlightsInToolbar(b, yPositionOnScreen)
-
-					instructionsList[i].WithLabels(label);
-
-					flag = true;
-				}
-
-				yield return instructionsList[i];
-			}
-
-			if (!flag)
-			{
-				ModEntry.Instance.Monitor.Log(
-					$"{nameof(ToolbarPatches)}.{nameof(Draw_Transpiler)} could not find target instruction(s) in {nameof(Toolbar.draw)}, so no changes were made.", LogLevel.Error);
-			}
-
-			yield break;
-		}
-
-		public static bool IsConfigEnableFavoriteItems() => ModEntry.Config.IsEnableFavoriteItems;
-	}
-
-	[HarmonyPatch(typeof(ShopMenu))]
-	public class ShopMenuPatches
-	{
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(ShopMenu.draw))]
-		public static void Draw_Postfix(ShopMenu __instance, SpriteBatch b)
-		{
-			try
-			{
-				ConvenientInventory.PostMenuDraw(__instance, b);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
-
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(ShopMenu.receiveLeftClick))]
-		public static bool ReceiveLeftClick_Prefix(ShopMenu __instance, int x, int y)
-		{
-			try
-			{
-				return ConvenientInventory.PreReceiveLeftClickInMenu(__instance, x, y);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
-			}
-
-			return true;
-		}
-
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(ShopMenu.receiveRightClick))]
-		public static bool ReceiveRightClick_Prefix(ShopMenu __instance, int x, int y)
-		{
-			try
-			{
-				return ConvenientInventory.PreReceiveRightClickInMenu(__instance, x, y);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
-			}
-
-			return true;
-		}
-	}
-
-	[HarmonyPatch(typeof(ItemGrabMenu))]
-	public class ItemGrabMenuPatches
-    {
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(ItemGrabMenu.organizeItemsInList))]
-		public static bool OrganizeItemsInList_Prefix(ItemGrabMenu __instance, out Item[] __state, IList<Item> items)
-		{
-			__state = null;
-
-			if (!ModEntry.Config.IsEnableFavoriteItems)
-            {
-				return true;
-            }
-
-			try
-			{
-				// Only call when this is the player's inventory
-				if (items == Game1.player.Items)
-				{
-					__state = ConvenientInventory.ExtractFavoriteItemsFromList(items);
-				}
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(OrganizeItemsInList_Prefix)}:\n{e}", LogLevel.Error);
-			}
-
-			return true;
-		}
-
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(ItemGrabMenu.organizeItemsInList))]
-		public static void OrganizeItemsInList_Postfix(ItemGrabMenu __instance, Item[] __state, IList<Item> items)
-		{
-			if (!ModEntry.Config.IsEnableFavoriteItems)
-			{
-				return;
-			}
-
-			try
-			{
-				// Only call when this is the player's inventory
-				if (items == Game1.player.Items)
-				{
-					ConvenientInventory.ReinsertExtractedFavoriteItemsIntoList(__state, items);
-				}
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(OrganizeItemsInList_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
-
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(ItemGrabMenu.FillOutStacks))]
-		public static bool FillOutStacks_Prefix(ItemGrabMenu __instance, out Item[] __state)
-		{
-			__state = null;
-
-			if (!ModEntry.Config.IsEnableFavoriteItems)
-			{
-				return true;
-			}
-
-			try
-			{
-				__state = ConvenientInventory.ExtractFavoriteItemsFromList(__instance.inventory.actualInventory);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(FillOutStacks_Prefix)}:\n{e}", LogLevel.Error);
-			}
-
-			return true;
-		}
-
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(ItemGrabMenu.FillOutStacks))]
-		public static void FillOutStacks_Postfix(ItemGrabMenu __instance, Item[] __state)
-		{
-			if (!ModEntry.Config.IsEnableFavoriteItems)
-			{
-				return;
-			}
-
-			try
-			{
-				ConvenientInventory.ReinsertExtractedFavoriteItemsIntoList(__state, __instance.inventory.actualInventory, false);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(FillOutStacks_Postfix)}:\n{e}", LogLevel.Error);
-			}
-		}
-	}
-
-	[HarmonyPatch(typeof(Item))]
-	public class ItemPatches
-    {
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(Item.canBeTrashed))]
-		public static bool CanBeTrashed_Prefix(ref bool __result)
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(MenuWithInventory.receiveRightClick))]
+        public static bool ReceiveRightClick_Prefix(MenuWithInventory __instance, int x, int y)
         {
-			if (ModEntry.Config.IsEnableFavoriteItems && ConvenientInventory.FavoriteItemsIsItemSelected)
-			{
-				if (!(Game1.activeClickableMenu is ItemGrabMenu itemGrabMenu && itemGrabMenu.shippingBin))
-				{
-					__result = false;
-					return false;
-				}
-			}
-
-			return true;
-        }
-	}
-
-	[HarmonyPatch(typeof(Farmer))]
-	public class FarmerPatches
-    {
-		[HarmonyPostfix]
-		[HarmonyPatch(nameof(Farmer.shiftToolbar))]
-		public static void ShiftToolbar_Postfix(Farmer __instance, bool right)
-		{
-			if (!ModEntry.Config.IsEnableFavoriteItems)
-			{
-				return;
-			}
-
-			try
-			{
-				// Game logic
-				if (__instance.Items == null || __instance.Items.Count < 12 || __instance.UsingTool || Game1.dialogueUp || (!Game1.pickingTool && !Game1.player.CanMove) || __instance.areAllItemsNull() || Game1.eventUp || Game1.farmEvent != null)
-				{
-					return;
-				}
-
-				ConvenientInventory.ShiftToolbar(right);
-			}
-			catch (Exception e)
+            try
             {
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ShiftToolbar_Postfix)}:\n{e}", LogLevel.Error);
+                return ConvenientInventory.PreReceiveRightClickInMenu(__instance, x, y);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
+            }
+
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(InventoryMenu))]
+    public class InventoryMenuPatches
+    {
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(InventoryMenu.draw))]
+        [HarmonyPatch(new Type[] { typeof(SpriteBatch), typeof(int), typeof(int), typeof(int) })]
+        public static IEnumerable<CodeInstruction> Draw_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator ilg)
+        {
+            MethodInfo isPlayerInventory = AccessTools.Method(typeof(ConvenientInventory), nameof(ConvenientInventory.IsPlayerInventory));
+            MethodInfo drawFavoriteItemSlotHighlights = AccessTools.Method(typeof(ConvenientInventory), nameof(ConvenientInventory.DrawFavoriteItemSlotHighlights));
+
+            MethodInfo isConfigEnableFavoriteItems = AccessTools.Method(typeof(InventoryMenuPatches), nameof(InventoryMenuPatches.IsConfigEnableFavoriteItems));
+
+            List<CodeInstruction> instructionsList = instructions.ToList();
+
+            bool flag = false;
+
+            for (int i = 0; i < instructionsList.Count; i++)
+            {
+                // Find instruction at start of (int k = 0; k < this.capacity; k++){} block
+                // IL_02d0 (instructionsList[?])
+                if (i < instructionsList.Count - 2
+                    && instructionsList[i].opcode == OpCodes.Ldc_I4_0
+                    && instructionsList[i + 1].opcode == OpCodes.Stloc_S && (instructionsList[i + 1].operand as LocalBuilder)?.LocalIndex == 9
+                    && instructionsList[i + 2].opcode == OpCodes.Br)
+                {
+                    Label label = ilg.DefineLabel();
+
+                    yield return new CodeInstruction(OpCodes.Ldarg_0) { labels = instructionsList[i].ExtractLabels() }; // load this InventoryMenu instance (arg 0)
+                    yield return new CodeInstruction(OpCodes.Call, isPlayerInventory);                                  // call IsPlayerInventory(this)
+                    yield return new CodeInstruction(OpCodes.Brfalse, label);                                           // break if call => false
+
+                    yield return new CodeInstruction(OpCodes.Call, isConfigEnableFavoriteItems);                        // call helper method
+                    yield return new CodeInstruction(OpCodes.Brfalse, label);                                           // break if call => false
+
+                    yield return new CodeInstruction(OpCodes.Ldarg_1);                                                  // load SpriteBatch "b" (arg 1)
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);                                                  // load this InventoryMenu instance (arg 0)
+                    yield return new CodeInstruction(OpCodes.Call, drawFavoriteItemSlotHighlights);                     // call DrawFavoriteItemSlotHighlights(b, this)
+
+                    instructionsList[i].WithLabels(label);
+
+                    flag = true;
+                }
+
+                yield return instructionsList[i];
+            }
+
+            if (!flag)
+            {
+                ModEntry.Instance.Monitor.Log(
+                    $"{nameof(InventoryMenuPatches)}.{nameof(Draw_Transpiler)} could not find target instruction(s) in {nameof(InventoryMenu.draw)}, so no changes were made.", LogLevel.Error);
+            }
+
+            yield break;
+        }
+
+        public static bool IsConfigEnableFavoriteItems() => ModEntry.Config.IsEnableFavoriteItems;
+
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(InventoryMenu.draw))]
+        [HarmonyPatch(new Type[] { typeof(SpriteBatch), typeof(int), typeof(int), typeof(int) })]
+        public static void Draw_Postfix(InventoryMenu __instance, SpriteBatch b)
+        {
+            try
+            {
+                if (ConvenientInventory.IsPlayerInventory(__instance))
+                {
+                    ConvenientInventory.PostMenuDraw(__instance, b);
+                }
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Toolbar))]
+    public class ToolbarPatches
+    {
+        [HarmonyTranspiler]
+        [HarmonyPatch(nameof(Toolbar.draw))]
+        [HarmonyPatch(new Type[] { typeof(SpriteBatch) })]
+        public static IEnumerable<CodeInstruction> Draw_Transpiler(IEnumerable<CodeInstruction> instructions, ILGenerator ilg)
+        {
+            MethodInfo isConfigEnableFavoriteItems = AccessTools.Method(typeof(ToolbarPatches), nameof(ToolbarPatches.IsConfigEnableFavoriteItems));
+            MethodInfo DrawFavoriteItemSlotHighlightsInToolbar = AccessTools.Method(typeof(ConvenientInventory), nameof(ConvenientInventory.DrawFavoriteItemSlotHighlightsInToolbar));
+
+            FieldInfo yPositionOnScreen = typeof(Toolbar).GetField("yPositionOnScreen", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            FieldInfo transparency = typeof(Toolbar).GetField("transparency", BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+            FieldInfo slotText = typeof(Toolbar).GetField("slotText", BindingFlags.Public | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+
+            List<CodeInstruction> instructionsList = instructions.ToList();
+
+            bool flag = false;
+
+            for (int i = 0; i < instructionsList.Count; i++)
+            {
+                // Find instruction after for(int j = 0; j < 12; j++){} block
+                // IL_027b (instructionsList[229])
+                if (i > 0 && i < instructionsList.Count - 2
+                    && instructionsList[i - 1].opcode == OpCodes.Blt
+                    && instructionsList[i].opcode == OpCodes.Ldc_I4_0
+                    && instructionsList[i + 1].opcode == OpCodes.Stloc_S && (instructionsList[i + 1].operand as LocalBuilder)?.LocalIndex == 9
+                    && instructionsList[i + 2].opcode == OpCodes.Br)
+                {
+                    Label label = ilg.DefineLabel();
+
+                    yield return new CodeInstruction(OpCodes.Call, isConfigEnableFavoriteItems)                 // call helper method
+                    {
+                        labels = instructionsList[i].ExtractLabels()
+                    };
+                    yield return new CodeInstruction(OpCodes.Brfalse, label);                                   // break if call => false
+
+                    yield return new CodeInstruction(OpCodes.Ldarg_1);                                          // load SpriteBatch "b" (arg 1)
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);                                          // load this (arg0)
+                    yield return new CodeInstruction(OpCodes.Ldfld, yPositionOnScreen);                         // load local variable "this.yPositionOnScreen"
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);                                          // load this (arg0)
+                    yield return new CodeInstruction(OpCodes.Ldfld, transparency);                              // load local variable "this.transparency"
+                    yield return new CodeInstruction(OpCodes.Ldarg_0);                                          // load this (arg0)
+                    yield return new CodeInstruction(OpCodes.Ldfld, slotText);                                  // load local variable "this.slotText"
+                    yield return new CodeInstruction(OpCodes.Call, DrawFavoriteItemSlotHighlightsInToolbar);    // call DrawFavoriteItemSlotHighlightsInToolbar(b, yPositionOnScreen)
+
+                    instructionsList[i].WithLabels(label);
+
+                    flag = true;
+                }
+
+                yield return instructionsList[i];
+            }
+
+            if (!flag)
+            {
+                ModEntry.Instance.Monitor.Log(
+                    $"{nameof(ToolbarPatches)}.{nameof(Draw_Transpiler)} could not find target instruction(s) in {nameof(Toolbar.draw)}, so no changes were made.", LogLevel.Error);
+            }
+
+            yield break;
+        }
+
+        public static bool IsConfigEnableFavoriteItems() => ModEntry.Config.IsEnableFavoriteItems;
+    }
+
+    [HarmonyPatch(typeof(ShopMenu))]
+    public class ShopMenuPatches
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(ShopMenu.draw))]
+        public static void Draw_Postfix(ShopMenu __instance, SpriteBatch b)
+        {
+            try
+            {
+                ConvenientInventory.PostMenuDraw(__instance, b);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(Draw_Postfix)}:\n{e}", LogLevel.Error);
             }
         }
 
-		[HarmonyPrefix]
-		[HarmonyPatch(nameof(Farmer.reduceActiveItemByOne))]
-		public static bool ReduceActiveItemByOne_Prefix(Farmer __instance)
-		{
-			if (!ModEntry.Config.IsEnableFavoriteItems)
-			{
-				return true;
-			}
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(ShopMenu.receiveLeftClick))]
+        public static bool ReceiveLeftClick_Prefix(ShopMenu __instance, int x, int y)
+        {
+            try
+            {
+                return ConvenientInventory.PreReceiveLeftClickInMenu(__instance, x, y);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveLeftClick_Prefix)}:\n{e}", LogLevel.Error);
+            }
 
-			try
-			{
-				ConvenientInventory.PreFarmerReduceActiveItemByOne(__instance);
-			}
-			catch (Exception e)
-			{
-				ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReduceActiveItemByOne_Prefix)}:\n{e}", LogLevel.Error);
-			}
+            return true;
+        }
 
-			return true;
-		}
-	}
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(ShopMenu.receiveRightClick))]
+        public static bool ReceiveRightClick_Prefix(ShopMenu __instance, int x, int y)
+        {
+            try
+            {
+                return ConvenientInventory.PreReceiveRightClickInMenu(__instance, x, y);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReceiveRightClick_Prefix)}:\n{e}", LogLevel.Error);
+            }
+
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(ItemGrabMenu))]
+    public class ItemGrabMenuPatches
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(ItemGrabMenu.organizeItemsInList))]
+        public static bool OrganizeItemsInList_Prefix(ItemGrabMenu __instance, out Item[] __state, IList<Item> items)
+        {
+            __state = null;
+
+            if (!ModEntry.Config.IsEnableFavoriteItems)
+            {
+                return true;
+            }
+
+            try
+            {
+                // Only call when this is the player's inventory
+                if (items == Game1.player.Items)
+                {
+                    __state = ConvenientInventory.ExtractFavoriteItemsFromList(items);
+                }
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(OrganizeItemsInList_Prefix)}:\n{e}", LogLevel.Error);
+            }
+
+            return true;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(ItemGrabMenu.organizeItemsInList))]
+        public static void OrganizeItemsInList_Postfix(ItemGrabMenu __instance, Item[] __state, IList<Item> items)
+        {
+            if (!ModEntry.Config.IsEnableFavoriteItems)
+            {
+                return;
+            }
+
+            try
+            {
+                // Only call when this is the player's inventory
+                if (items == Game1.player.Items)
+                {
+                    ConvenientInventory.ReinsertExtractedFavoriteItemsIntoList(__state, items);
+                }
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(OrganizeItemsInList_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(ItemGrabMenu.FillOutStacks))]
+        public static bool FillOutStacks_Prefix(ItemGrabMenu __instance, out Item[] __state)
+        {
+            __state = null;
+
+            if (!ModEntry.Config.IsEnableFavoriteItems)
+            {
+                return true;
+            }
+
+            try
+            {
+                __state = ConvenientInventory.ExtractFavoriteItemsFromList(__instance.inventory.actualInventory);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(FillOutStacks_Prefix)}:\n{e}", LogLevel.Error);
+            }
+
+            return true;
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(ItemGrabMenu.FillOutStacks))]
+        public static void FillOutStacks_Postfix(ItemGrabMenu __instance, Item[] __state)
+        {
+            if (!ModEntry.Config.IsEnableFavoriteItems)
+            {
+                return;
+            }
+
+            try
+            {
+                ConvenientInventory.ReinsertExtractedFavoriteItemsIntoList(__state, __instance.inventory.actualInventory, false);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(FillOutStacks_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
+    }
+
+    [HarmonyPatch(typeof(Item))]
+    public class ItemPatches
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(Item.canBeTrashed))]
+        public static bool CanBeTrashed_Prefix(ref bool __result)
+        {
+            if (ModEntry.Config.IsEnableFavoriteItems && ConvenientInventory.FavoriteItemsIsItemSelected)
+            {
+                if (!(Game1.activeClickableMenu is ItemGrabMenu itemGrabMenu && itemGrabMenu.shippingBin))
+                {
+                    __result = false;
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+
+    [HarmonyPatch(typeof(Farmer))]
+    public class FarmerPatches
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(nameof(Farmer.shiftToolbar))]
+        public static void ShiftToolbar_Postfix(Farmer __instance, bool right)
+        {
+            if (!ModEntry.Config.IsEnableFavoriteItems)
+            {
+                return;
+            }
+
+            try
+            {
+                // Game logic
+                if (__instance.Items == null || __instance.Items.Count < 12 || __instance.UsingTool || Game1.dialogueUp || (!Game1.pickingTool && !Game1.player.CanMove) || __instance.areAllItemsNull() || Game1.eventUp || Game1.farmEvent != null)
+                {
+                    return;
+                }
+
+                ConvenientInventory.ShiftToolbar(right);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(ShiftToolbar_Postfix)}:\n{e}", LogLevel.Error);
+            }
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(nameof(Farmer.reduceActiveItemByOne))]
+        public static bool ReduceActiveItemByOne_Prefix(Farmer __instance)
+        {
+            if (!ModEntry.Config.IsEnableFavoriteItems)
+            {
+                return true;
+            }
+
+            try
+            {
+                ConvenientInventory.PreFarmerReduceActiveItemByOne(__instance);
+            }
+            catch (Exception e)
+            {
+                ModEntry.Instance.Monitor.Log($"Failed in {nameof(ReduceActiveItemByOne_Prefix)}:\n{e}", LogLevel.Error);
+            }
+
+            return true;
+        }
+    }
 }

--- a/ConvenientInventory/ConvenientInventory/QuickStackLogic.cs
+++ b/ConvenientInventory/ConvenientInventory/QuickStackLogic.cs
@@ -12,752 +12,752 @@ using static StardewValley.Menus.ItemGrabMenu;
 
 namespace ConvenientInventory
 {
-	public static class QuickStackLogic
-	{
-		private class ChestWithDistance
-		{
-			public Chest Chest { get; private set; }
+    public static class QuickStackLogic
+    {
+        private class ChestWithDistance
+        {
+            public Chest Chest { get; private set; }
 
-			public double Distance { get; private set; }
+            public double Distance { get; private set; }
 
-			public ChestWithDistance(Chest chest, double distance)
-			{
-				Chest = chest;
-				Distance = distance;
-			}
-		}
+            public ChestWithDistance(Chest chest, double distance)
+            {
+                Chest = chest;
+                Distance = distance;
+            }
+        }
 
-		private class TypedChestWithDistance
-		{
-			public TypedChest TypedChest { get; private set; }
+        private class TypedChestWithDistance
+        {
+            public TypedChest TypedChest { get; private set; }
 
-			public double Distance { get; private set; }
+            public double Distance { get; private set; }
 
-			public TypedChestWithDistance(TypedChest chest, double distance)
-			{
-				TypedChest = chest;
-				Distance = distance;
-			}
-		}
+            public TypedChestWithDistance(TypedChest chest, double distance)
+            {
+                TypedChest = chest;
+                Distance = distance;
+            }
+        }
 
-		public static bool StackToNearbyChests(int range, InventoryPage inventoryPage)
-		{
-			if (inventoryPage == null)
-			{
-				return false;
-			}
+        public static bool StackToNearbyChests(int range, InventoryPage inventoryPage)
+        {
+            if (inventoryPage == null)
+            {
+                return false;
+            }
 
-			bool movedAtLeastOneTotal = false;
-			Farmer who = Game1.player;
+            bool movedAtLeastOneTotal = false;
+            Farmer who = Game1.player;
 
-			List<Chest> chests = GetChestsAroundFarmer(who, range, true);
+            List<Chest> chests = GetChestsAroundFarmer(who, range, true);
 
-			foreach (Chest chest in chests)
-			{
-				List<Item> stackOverflowItems = new List<Item>();
+            foreach (Chest chest in chests)
+            {
+                List<Item> stackOverflowItems = new List<Item>();
 
-				Netcode.NetObjectList<Item> chestItems = (chest.SpecialChestType == Chest.SpecialChestTypes.MiniShippingBin || chest.SpecialChestType == Chest.SpecialChestTypes.JunimoChest)
-						? chest.GetItemsForPlayer(who.UniqueMultiplayerID)
-						: chest.items;
+                Netcode.NetObjectList<Item> chestItems = (chest.SpecialChestType == Chest.SpecialChestTypes.MiniShippingBin || chest.SpecialChestType == Chest.SpecialChestTypes.JunimoChest)
+                        ? chest.GetItemsForPlayer(who.UniqueMultiplayerID)
+                        : chest.items;
 
-				// Fill chest stacks with player inventory items
-				foreach (Item chestItem in chestItems)
-				{
-					if (chestItem is null)
-					{
-						continue;
-					}
+                // Fill chest stacks with player inventory items
+                foreach (Item chestItem in chestItems)
+                {
+                    if (chestItem is null)
+                    {
+                        continue;
+                    }
 
-					IList<Item> playerInventory = inventoryPage.inventory.actualInventory;
+                    IList<Item> playerInventory = inventoryPage.inventory.actualInventory;
 
-					foreach (Item playerItem in playerInventory)
-					{
-						if (playerItem is null || !playerItem.canStackWith(chestItem))
-						{
-							continue;
-						}
-
-						if (ModEntry.Config.IsEnableFavoriteItems && ConvenientInventory.FavoriteItemSlots[playerInventory.IndexOf(playerItem)])
+                    foreach (Item playerItem in playerInventory)
+                    {
+                        if (playerItem is null || !playerItem.canStackWith(chestItem))
                         {
-							// Skip favorited items
-							continue;
+                            continue;
                         }
 
-						int beforeStack = playerItem.Stack;
-						playerItem.Stack = chestItem.addToStack(playerItem);
-						bool movedAtLeastOne = beforeStack != playerItem.Stack;
-
-						movedAtLeastOneTotal = movedAtLeastOneTotal || movedAtLeastOne;
-
-						if (movedAtLeastOne)
-						{
-							ClickableComponent inventoryComponent = inventoryPage.inventory.inventory[playerInventory.IndexOf(playerItem)];
-
-							ConvenientInventory.AddTransferredItemSprite(new TransferredItemSprite(
-								playerItem.getOne(), inventoryComponent.bounds.X, inventoryComponent.bounds.Y)
-							);
-							
-							if (playerItem.Stack == 0)
-							{
-								who.removeItemFromInventory(playerItem);
-							}
-						}
-
-						if (chestItem.Stack == chestItem.maximumStackSize())
-						{
-							if (ModEntry.Config.IsQuickStackOverflowItems)
-							{
-								stackOverflowItems.Add(chestItem.getOne());
-							}
-
-							inventoryPage.inventory.ShakeItem(playerItem);
-							break;
-						}
-					}
-				}
-
-				// Add overflow stacks to chest when applicable
-				if (ModEntry.Config.IsQuickStackOverflowItems && chestItems.Count < chest.GetActualCapacity())
-				{
-					IList<Item> playerInventory = inventoryPage.inventory.actualInventory;
-
-					foreach (Item stackOverflowItem in stackOverflowItems)
-					{
-						if (stackOverflowItem is null)
-						{
-							continue;
-						}
-
-						foreach (Item playerItem in playerInventory)
-						{
-							if (playerItem is null || !playerItem.canStackWith(stackOverflowItem))
-							{
-								continue;
-							}
-
-							if (ModEntry.Config.IsEnableFavoriteItems && ConvenientInventory.FavoriteItemSlots[playerInventory.IndexOf(playerItem)])
-							{
-								// Skip favorited items
-								continue;
-							}
-
-							int beforeStack = playerItem.Stack;
-							Item leftoverItem = chest.addItem(playerItem);
-							bool movedAtLeastOne = leftoverItem is null || beforeStack != leftoverItem.Stack;
-
-							movedAtLeastOneTotal = movedAtLeastOneTotal || movedAtLeastOne;
-
-							if (movedAtLeastOne)
-							{
-								ClickableComponent inventoryComponent = inventoryPage.inventory.inventory[playerInventory.IndexOf(playerItem)];
-
-								ConvenientInventory.AddTransferredItemSprite(new TransferredItemSprite(
-									playerItem.getOne(), inventoryComponent.bounds.X, inventoryComponent.bounds.Y)
-								);
-							}
-
-							if (leftoverItem is null)
-							{
-								who.removeItemFromInventory(playerItem);
-							}
-							else
-							{
-								inventoryPage.inventory.ShakeItem(playerItem);
-							}
-						}
-					}
-				}
-			}
-
-			Game1.playSound(movedAtLeastOneTotal ? "Ship" : "cancel");
-
-			return movedAtLeastOneTotal;
-		}
-
-		// To be used when not in the InventoryPage, accessed via hotkey.
-		public static bool StackToNearbyChests(int range)
-		{
-			bool movedAtLeastOneTotal = false;
-			Farmer who = Game1.player;
-
-			List<Chest> chests = GetChestsAroundFarmer(who, range, true);
-
-			foreach (Chest chest in chests)
-			{
-				List<Item> stackOverflowItems = new List<Item>();
-
-				Netcode.NetObjectList<Item> chestItems = (chest.SpecialChestType == Chest.SpecialChestTypes.MiniShippingBin || chest.SpecialChestType == Chest.SpecialChestTypes.JunimoChest)
-						? chest.GetItemsForPlayer(who.UniqueMultiplayerID)
-						: chest.items;
-
-				// Fill chest stacks with player inventory items
-				foreach (Item chestItem in chestItems)
-				{
-					if (chestItem is null)
-					{
-						continue;
-					}
-
-					IList<Item> playerInventory = who.Items;
-
-					foreach (Item playerItem in playerInventory)
-					{
-						if (playerItem is null || !playerItem.canStackWith(chestItem))
-						{
-							continue;
-						}
-
-						if (ModEntry.Config.IsEnableFavoriteItems && ConvenientInventory.FavoriteItemSlots[playerInventory.IndexOf(playerItem)])
-						{
-							// Skip favorited items
-							continue;
-						}
-
-						int beforeStack = playerItem.Stack;
-						playerItem.Stack = chestItem.addToStack(playerItem);
-						bool movedAtLeastOne = beforeStack != playerItem.Stack;
-
-						movedAtLeastOneTotal = movedAtLeastOneTotal || movedAtLeastOne;
-
-						if (movedAtLeastOne && playerItem.Stack == 0)
-						{
-							who.removeItemFromInventory(playerItem);
-						}
-
-						if (chestItem.Stack == chestItem.maximumStackSize())
-						{
-							if (ModEntry.Config.IsQuickStackOverflowItems)
-							{
-								stackOverflowItems.Add(chestItem.getOne());
-							}
-
-							break;
-						}
-					}
-				}
-
-				// Add overflow stacks to chest when applicable
-				if (ModEntry.Config.IsQuickStackOverflowItems && chestItems.Count < chest.GetActualCapacity())
-				{
-					IList<Item> playerInventory = who.Items;
-
-					foreach (Item stackOverflowItem in stackOverflowItems)
-					{
-						if (stackOverflowItem is null)
-						{
-							continue;
-						}
-
-						foreach (Item playerItem in playerInventory)
-						{
-							if (playerItem is null || !playerItem.canStackWith(stackOverflowItem))
-							{
-								continue;
-							}
-
-							if (ModEntry.Config.IsEnableFavoriteItems && ConvenientInventory.FavoriteItemSlots[playerInventory.IndexOf(playerItem)])
-							{
-								// Skip favorited items
-								continue;
-							}
-
-							int beforeStack = playerItem.Stack;
-							Item leftoverItem = chest.addItem(playerItem);
-							bool movedAtLeastOne = leftoverItem is null || beforeStack != leftoverItem.Stack;
-
-							movedAtLeastOneTotal = movedAtLeastOneTotal || movedAtLeastOne;
-
-							if (leftoverItem is null)
-							{
-								who.removeItemFromInventory(playerItem);
-							}
-						}
-					}
-				}
-			}
-
-			Game1.playSound(movedAtLeastOneTotal ? "Ship" : "cancel");
-
-			return movedAtLeastOneTotal;
-		}
-
-		public static List<Chest> GetChestsAroundFarmer(Farmer who, int range, bool sorted = false)
-		{
-			if (who is null)
-			{
-				return new List<Chest>();
-			}
-
-			Vector2 farmerPosition = who.getStandingPosition();
-			Point farmerTileLocation = who.getTileLocationPoint();
-			GameLocation gameLocation = who.currentLocation;
-
-			return sorted
-				? GetNearbyChestsWithDistance(farmerPosition, range, gameLocation).OrderBy(x => x.Distance).Select(x => x.Chest).ToList()
-				: GetNearbyChests(farmerTileLocation, range, gameLocation);
-		}
-
-		public static List<TypedChest> GetTypedChestsAroundFarmer(Farmer who, int range, bool sorted = false)
-		{
-			if (who is null)
-			{
-				return new List<TypedChest>();
-			}
-
-			Vector2 farmerPosition = who.getStandingPosition();
-			Point farmerTileLocation = who.getTileLocationPoint();
-			GameLocation gameLocation = who.currentLocation;
-
-			return sorted 
-				? GetNearbyTypedChestsWithDistance(farmerPosition, range, gameLocation).OrderBy(x => x.Distance).Select(x => x.TypedChest).ToList()
-				: GetNearbyTypedChests(farmerTileLocation, range, gameLocation);
-		}
-
-		// From origin, return all nearby chests, including the point-distance from their tile-center to origin, within a given square range.
-		private static List<ChestWithDistance> GetNearbyChestsWithDistance(Vector2 origin, int range, GameLocation gameLocation)
-		{
-			var dChests = new List<ChestWithDistance>((2 * range + 1) * (2 * range + 1));
-			Vector2 originTileCenterPosition = GetTileCenterPosition(GetTileLocation(origin));
-			Vector2 tileLocation = Vector2.Zero;
-			int tx, ty, dx, dy;
-
-			// Chests (includes mini fridge, stone chest, mini shipping bin, junimo chest, ...)
-			for (int x = -range; x <= range; x++)
-			{
-				for (int y = -range; y <= range; y++)
-				{
-					tx = (int)originTileCenterPosition.X + (x * Game1.tileSize);
-					ty = (int)originTileCenterPosition.Y + (y * Game1.tileSize);
-
-					tileLocation.X = tx / Game1.tileSize;
-					tileLocation.Y = ty / Game1.tileSize;
-
-					if (gameLocation.objects.TryGetValue(tileLocation, out StardewValley.Object obj) && obj is Chest chest)
-					{
-						// Make sure chest is not in-use by another player (easy fix to avoid item deletion)
-						if (chest.GetMutex().IsLocked())
-						{
-							continue;
-						}
-
-						dx = tx - (int)origin.X;
-						dy = ty - (int)origin.Y;
-
-						dChests.Add(new ChestWithDistance(chest, Math.Sqrt(dx * dx + dy * dy)));
-					}
-				}
-			}
-
-			// Kitchen fridge
-			if (gameLocation is FarmHouse farmHouse && farmHouse.upgradeLevel > 0)  // Kitchen only exists when upgradeLevel > 0
-			{
-				Vector2 fridgeTileCenterPosition = GetTileCenterPosition(farmHouse.fridgePosition);
-
-				if (IsPositionWithinRange(origin, fridgeTileCenterPosition, range))
-				{
-					if (farmHouse.fridge.Value != null && !farmHouse.fridge.Value.GetMutex().IsLocked())
-					{
-						dx = (int)fridgeTileCenterPosition.X - (int)origin.X;
-						dy = (int)fridgeTileCenterPosition.Y - (int)origin.Y;
-
-						dChests.Add(new ChestWithDistance(farmHouse.fridge.Value, Math.Sqrt(dx * dx + dy * dy)));
-					}
-				}
-			}
-
-			// Island kitchen fridge
-			if (gameLocation is IslandFarmHouse islandFarmHouse)
-			{
-				Vector2 fridgeTileCenterPosition = GetTileCenterPosition(islandFarmHouse.fridgePosition);
-
-				if (IsPositionWithinRange(origin, fridgeTileCenterPosition, range))
-				{
-					if (islandFarmHouse.fridge.Value != null && !islandFarmHouse.fridge.Value.GetMutex().IsLocked())
-					{
-						dx = (int)fridgeTileCenterPosition.X - (int)origin.X;
-						dy = (int)fridgeTileCenterPosition.Y - (int)origin.Y;
-
-						dChests.Add(new ChestWithDistance(islandFarmHouse.fridge.Value, Math.Sqrt(dx * dx + dy * dy)));
-					}
-				}
-			}
-
-			// Buildings
-			if (ModEntry.Config.IsQuickStackIntoBuildingsWithInventories)
-			{
-				if (gameLocation is BuildableGameLocation buildableGameLocation)
-				{
-					foreach (Building building in buildableGameLocation.buildings)
-					{
-						Vector2 buildingTileCenterPosition = GetTileCenterPosition(building.tileX.Value, building.tileY.Value);
-
-						if (IsPositionWithinRange(origin, buildingTileCenterPosition, range))
-						{
-							if (building is JunimoHut junimoHut)
-							{
-								if (junimoHut.output.Value.GetMutex().IsLocked())
-								{
-									continue;
-								}
-
-								dx = (int)buildingTileCenterPosition.X - (int)origin.X;
-								dy = (int)buildingTileCenterPosition.Y - (int)origin.Y;
-
-								dChests.Add(new ChestWithDistance(junimoHut.output.Value, Math.Sqrt(dx * dx + dy * dy)));
-							}
-							else if (building is Mill mill)
-							{
-								if (mill.isUnderConstruction() || mill.input.Value.GetMutex().IsLocked())
-								{
-									continue;
-								}
-
-								dx = (int)buildingTileCenterPosition.X - (int)origin.X;
-								dy = (int)buildingTileCenterPosition.Y - (int)origin.Y;
-
-								dChests.Add(new ChestWithDistance(mill.input.Value, Math.Sqrt(dx * dx + dy * dy)));
-							}
-						}
-					}
-				}
-			}
-
-			return dChests;
-		}
-
-		private static List<TypedChestWithDistance> GetNearbyTypedChestsWithDistance(Vector2 origin, int range, GameLocation gameLocation)
-		{
-			var tdChests = new List<TypedChestWithDistance>((2 * range + 1) * (2 * range + 1));
-			Vector2 originTileCenterPosition = GetTileCenterPosition(GetTileLocation(origin));
-			Vector2 tileLocation = Vector2.Zero;
-			int tx, ty, dx, dy;
-
-			// Chests (includes mini fridge, stone chest, mini shipping bin, junimo chest, ...)
-			for (int x = -range; x <= range; x++)
-			{
-				for (int y = -range; y <= range; y++)
-				{
-					tx = (int)originTileCenterPosition.X + (x * Game1.tileSize);
-					ty = (int)originTileCenterPosition.Y + (y * Game1.tileSize);
-
-					tileLocation.X = tx / Game1.tileSize;
-					tileLocation.Y = ty / Game1.tileSize;
-
-					if (gameLocation.objects.TryGetValue(tileLocation, out StardewValley.Object obj) && obj is Chest chest)
-					{
-						// Make sure chest is not in-use by another player (easy fix to avoid item deletion)
-						if (chest.GetMutex().IsLocked())
-						{
-							continue;
-						}
-
-						dx = tx - (int)origin.X;
-						dy = ty - (int)origin.Y;
-
-						ChestType chestType = TypedChest.GetChestType(chest);
-
-						var typedChest = new TypedChest(chest, chestType);
-
-						tdChests.Add(new TypedChestWithDistance(typedChest, Math.Sqrt(dx * dx + dy * dy)));
-					}
-				}
-			}
-
-			// Kitchen fridge
-			if (gameLocation is FarmHouse farmHouse && farmHouse.upgradeLevel > 0)  // Kitchen only exists when upgradeLevel > 0
-			{
-				Vector2 fridgeTileCenterPosition = GetTileCenterPosition(farmHouse.fridgePosition);
-
-				if (IsPositionWithinRange(origin, fridgeTileCenterPosition, range))
-				{
-					if (farmHouse.fridge.Value != null && !farmHouse.fridge.Value.GetMutex().IsLocked())
-					{
-						dx = (int)fridgeTileCenterPosition.X - (int)origin.X;
-						dy = (int)fridgeTileCenterPosition.Y - (int)origin.Y;
-
-						var typedChest = new TypedChest(farmHouse.fridge.Value, ChestType.Fridge);
-
-						tdChests.Add(new TypedChestWithDistance(typedChest, Math.Sqrt(dx * dx + dy * dy)));
-					}
-				}
-			}
-
-			// Island kitchen fridge
-			if (gameLocation is IslandFarmHouse islandFarmHouse)
-			{
-				Vector2 fridgeTileCenterPosition = GetTileCenterPosition(islandFarmHouse.fridgePosition);
-
-				if (IsPositionWithinRange(origin, fridgeTileCenterPosition, range))
-				{
-					if (islandFarmHouse.fridge.Value != null && !islandFarmHouse.fridge.Value.GetMutex().IsLocked())
-					{
-						dx = (int)fridgeTileCenterPosition.X - (int)origin.X;
-						dy = (int)fridgeTileCenterPosition.Y - (int)origin.Y;
-
-						var typedChest = new TypedChest(islandFarmHouse.fridge.Value, ChestType.Fridge);
-
-						tdChests.Add(new TypedChestWithDistance(typedChest, Math.Sqrt(dx * dx + dy * dy)));
-					}
-				}
-			}
-
-			// Buildings
-			if (ModEntry.Config.IsQuickStackIntoBuildingsWithInventories)
-			{
-				if (gameLocation is BuildableGameLocation buildableGameLocation)
-				{
-					foreach (Building building in buildableGameLocation.buildings)
-					{
-						Vector2 buildingTileCenterPosition = GetTileCenterPosition(building.tileX.Value, building.tileY.Value);
-
-						if (IsPositionWithinRange(origin, buildingTileCenterPosition, range))
-						{
-							if (building is JunimoHut junimoHut)
-							{
-								if (junimoHut.output.Value.GetMutex().IsLocked())
-								{
-									continue;
-								}
-
-								dx = (int)buildingTileCenterPosition.X - (int)origin.X;
-								dy = (int)buildingTileCenterPosition.Y - (int)origin.Y;
-
-								var typedChest = new TypedChest(junimoHut.output.Value, ChestType.JunimoHut);
-
-								tdChests.Add(new TypedChestWithDistance(typedChest, Math.Sqrt(dx * dx + dy * dy)));
-							}
-							else if (building is Mill mill)
-							{
-								if (mill.isUnderConstruction() || mill.input.Value.GetMutex().IsLocked())
-								{
-									continue;
-								}
-
-								dx = (int)buildingTileCenterPosition.X - (int)origin.X;
-								dy = (int)buildingTileCenterPosition.Y - (int)origin.Y;
-
-								var typedChest = new TypedChest(mill.input.Value, ChestType.Mill);
-
-								tdChests.Add(new TypedChestWithDistance(typedChest, Math.Sqrt(dx * dx + dy * dy)));
-							}
-						}
-					}
-				}
-			}
-
-			return tdChests;
-		}
-
-		private static List<Chest> GetNearbyChests(Point originTile, int range, GameLocation gameLocation)
-		{
-			var chests = new List<Chest>((2 * range + 1) * (2 * range + 1));
-
-			// Chests
-			for (int dx = -range; dx <= range; dx++)
-			{
-				for (int dy = -range; dy <= range; dy++)
-				{
-					Vector2 tileLocation = new Vector2(originTile.X + dx, originTile.Y + dy);
-
-					if (gameLocation.objects.TryGetValue(tileLocation, out StardewValley.Object obj) && obj is Chest chest)
-					{
-						if (chest.GetMutex().IsLocked())
-						{
-							continue;
-						}
-
-						chests.Add(chest);
-					}
-				}
-			}
-
-			// Kitchen fridge
-			if (gameLocation is FarmHouse farmHouse && farmHouse.upgradeLevel >= 1) //Lvl 1,2,3 is where you have fridge upgrade
-			{
-				Point kitchenStandingSpot = farmHouse.getKitchenStandingSpot();
-				Point fridgeTileLocation = new Point(kitchenStandingSpot.X + 2, kitchenStandingSpot.Y - 1); //Fridge spot relative to kitchen spot
-
-				if (IsTileWithinRange(originTile, fridgeTileLocation, range))
-				{
-					if (farmHouse.fridge.Value != null && !farmHouse.fridge.Value.GetMutex().IsLocked())
-					{
-						chests.Add(farmHouse.fridge.Value);
-					}
-				}
-			}
-
-			// Island kitchen fridge
-			if (gameLocation is IslandFarmHouse islandFarmHouse)
-			{
-				Point fridgeTileLocation = islandFarmHouse.fridgePosition;
-
-				if (IsTileWithinRange(originTile, fridgeTileLocation, range))
-				{
-					if (islandFarmHouse.fridge.Value != null && !islandFarmHouse.fridge.Value.GetMutex().IsLocked())
-					{
-						chests.Add(islandFarmHouse.fridge.Value);
-					}
-				}
-			}
-
-			// Buildings
-			if (ModEntry.Config.IsQuickStackIntoBuildingsWithInventories)
-			{
-				if (gameLocation is BuildableGameLocation buildableGameLocation)
-				{
-					foreach (Building building in buildableGameLocation.buildings)
-					{
-						if (IsTileWithinRange(originTile, building.tileX.Value, building.tileY.Value, range))
-						{
-							if (building is JunimoHut junimoHut)
-							{
-								if (junimoHut.output.Value.GetMutex().IsLocked())
-								{
-									continue;
-								}
-
-								chests.Add(junimoHut.output.Value);
-							}
-							else if (building is Mill mill)
-							{
-								if (mill.input.Value.GetMutex().IsLocked())
-								{
-									continue;
-								}
-
-								chests.Add(mill.input.Value);
-							}
-						}
-					}
-				}
-			}
-
-			return chests;
-		}
-
-		private static List<TypedChest> GetNearbyTypedChests(Point originTile, int range, GameLocation gameLocation)
-		{
-			var tChests = new List<TypedChest>((2 * range + 1) * (2 * range + 1));
-
-			// Chests
-			for (int dx = -range; dx <= range; dx++)
-			{
-				for (int dy = -range; dy <= range; dy++)
-				{
-					Vector2 tileLocation = new Vector2(originTile.X + dx, originTile.Y + dy);
-
-					if (gameLocation.objects.TryGetValue(tileLocation, out StardewValley.Object obj) && obj is Chest chest)
-					{
-						if (chest.GetMutex().IsLocked())
-						{
-							continue;
-						}
-
-						ChestType chestType = TypedChest.GetChestType(chest);
-
-						tChests.Add(new TypedChest(chest, chestType));
-					}
-				}
-			}
-
-			// Kitchen fridge
-			if (gameLocation is FarmHouse farmHouse && farmHouse.upgradeLevel >= 1) //Lvl 1,2,3 is where you have fridge upgrade
-			{
-				Point kitchenStandingSpot = farmHouse.getKitchenStandingSpot();
-				Point fridgeTileLocation = new Point(kitchenStandingSpot.X + 2, kitchenStandingSpot.Y - 1); //Fridge spot relative to kitchen spot
-
-				if (IsTileWithinRange(originTile, fridgeTileLocation, range))
-				{
-					if (farmHouse.fridge.Value != null && !farmHouse.fridge.Value.GetMutex().IsLocked())
-					{
-						tChests.Add(new TypedChest(farmHouse.fridge.Value, ChestType.Fridge));
-					}
-				}
-			}
-
-			// Island kitchen fridge
-			if (gameLocation is IslandFarmHouse islandFarmHouse)
-			{
-				Point fridgeTileLocation = islandFarmHouse.fridgePosition;
-
-				if (IsTileWithinRange(originTile, fridgeTileLocation, range))
-				{
-					if (islandFarmHouse.fridge.Value != null && !islandFarmHouse.fridge.Value.GetMutex().IsLocked())
-					{
-						tChests.Add(new TypedChest(islandFarmHouse.fridge.Value, ChestType.Fridge));
-					}
-				}
-			}
-
-			// Buildings
-			if (ModEntry.Config.IsQuickStackIntoBuildingsWithInventories)
-			{
-				if (gameLocation is BuildableGameLocation buildableGameLocation)
-				{
-					foreach (Building building in buildableGameLocation.buildings)
-					{
-						if (IsTileWithinRange(originTile, building.tileX.Value, building.tileY.Value, range))
-						{
-							if (building is JunimoHut junimoHut)
-							{
-								if (junimoHut.output.Value.GetMutex().IsLocked())
-								{
-									continue;
-								}
-
-								tChests.Add(new TypedChest(junimoHut.output.Value, ChestType.JunimoHut));
-							}
-							else if (building is Mill mill)
-							{
-								if (mill.input.Value.GetMutex().IsLocked())
-								{
-									continue;
-								}
-
-								tChests.Add(new TypedChest(mill.input.Value, ChestType.Mill));
-							}
-						}
-					}
-				}
-			}
-
-			return tChests;
-		}
-
-		private static Point GetTileLocation(Vector2 position)
-		{
-			return new Point(
-				(int)position.X / Game1.tileSize,
-				(int)position.Y / Game1.tileSize);
-		}
-
-		private static Vector2 GetTileCenterPosition(Point tileLocation)
-		{
-			return new Vector2(
-				(tileLocation.X * Game1.tileSize) + (Game1.tileSize / 2),
-				(tileLocation.Y * Game1.tileSize) + (Game1.tileSize / 2));
-		}
-
-		private static Vector2 GetTileCenterPosition(int tileX, int tileY)
-		{
-			return new Vector2(
-				(tileX * Game1.tileSize) + (Game1.tileSize / 2),
-				(tileY * Game1.tileSize) + (Game1.tileSize / 2));
-		}
-
-		private static bool IsTileWithinRange(Point origin, Point target, int range)
-		{
-			return Math.Abs(origin.X - target.X) <= range && Math.Abs(origin.Y - target.Y) <= range;
-		}
-
-		private static bool IsTileWithinRange(Point origin, int targetX, int targetY, int range)
-		{
-			return Math.Abs(origin.X - targetX) <= range && Math.Abs(origin.Y - targetY) <= range;
-		}
-
-		private static bool IsPositionWithinRange(Vector2 origin, Vector2 target, int range)
-		{
-			return Math.Abs(origin.X - target.X) <= (range * Game1.tileSize) && Math.Abs(origin.Y - target.Y) <= (range * Game1.tileSize);
-		}
-	}
+                        if (ModEntry.Config.IsEnableFavoriteItems && ConvenientInventory.FavoriteItemSlots[playerInventory.IndexOf(playerItem)])
+                        {
+                            // Skip favorited items
+                            continue;
+                        }
+
+                        int beforeStack = playerItem.Stack;
+                        playerItem.Stack = chestItem.addToStack(playerItem);
+                        bool movedAtLeastOne = beforeStack != playerItem.Stack;
+
+                        movedAtLeastOneTotal = movedAtLeastOneTotal || movedAtLeastOne;
+
+                        if (movedAtLeastOne)
+                        {
+                            ClickableComponent inventoryComponent = inventoryPage.inventory.inventory[playerInventory.IndexOf(playerItem)];
+
+                            ConvenientInventory.AddTransferredItemSprite(new TransferredItemSprite(
+                                playerItem.getOne(), inventoryComponent.bounds.X, inventoryComponent.bounds.Y)
+                            );
+
+                            if (playerItem.Stack == 0)
+                            {
+                                who.removeItemFromInventory(playerItem);
+                            }
+                        }
+
+                        if (chestItem.Stack == chestItem.maximumStackSize())
+                        {
+                            if (ModEntry.Config.IsQuickStackOverflowItems)
+                            {
+                                stackOverflowItems.Add(chestItem.getOne());
+                            }
+
+                            inventoryPage.inventory.ShakeItem(playerItem);
+                            break;
+                        }
+                    }
+                }
+
+                // Add overflow stacks to chest when applicable
+                if (ModEntry.Config.IsQuickStackOverflowItems && chestItems.Count < chest.GetActualCapacity())
+                {
+                    IList<Item> playerInventory = inventoryPage.inventory.actualInventory;
+
+                    foreach (Item stackOverflowItem in stackOverflowItems)
+                    {
+                        if (stackOverflowItem is null)
+                        {
+                            continue;
+                        }
+
+                        foreach (Item playerItem in playerInventory)
+                        {
+                            if (playerItem is null || !playerItem.canStackWith(stackOverflowItem))
+                            {
+                                continue;
+                            }
+
+                            if (ModEntry.Config.IsEnableFavoriteItems && ConvenientInventory.FavoriteItemSlots[playerInventory.IndexOf(playerItem)])
+                            {
+                                // Skip favorited items
+                                continue;
+                            }
+
+                            int beforeStack = playerItem.Stack;
+                            Item leftoverItem = chest.addItem(playerItem);
+                            bool movedAtLeastOne = leftoverItem is null || beforeStack != leftoverItem.Stack;
+
+                            movedAtLeastOneTotal = movedAtLeastOneTotal || movedAtLeastOne;
+
+                            if (movedAtLeastOne)
+                            {
+                                ClickableComponent inventoryComponent = inventoryPage.inventory.inventory[playerInventory.IndexOf(playerItem)];
+
+                                ConvenientInventory.AddTransferredItemSprite(new TransferredItemSprite(
+                                    playerItem.getOne(), inventoryComponent.bounds.X, inventoryComponent.bounds.Y)
+                                );
+                            }
+
+                            if (leftoverItem is null)
+                            {
+                                who.removeItemFromInventory(playerItem);
+                            }
+                            else
+                            {
+                                inventoryPage.inventory.ShakeItem(playerItem);
+                            }
+                        }
+                    }
+                }
+            }
+
+            Game1.playSound(movedAtLeastOneTotal ? "Ship" : "cancel");
+
+            return movedAtLeastOneTotal;
+        }
+
+        // To be used when not in the InventoryPage, accessed via hotkey.
+        public static bool StackToNearbyChests(int range)
+        {
+            bool movedAtLeastOneTotal = false;
+            Farmer who = Game1.player;
+
+            List<Chest> chests = GetChestsAroundFarmer(who, range, true);
+
+            foreach (Chest chest in chests)
+            {
+                List<Item> stackOverflowItems = new List<Item>();
+
+                Netcode.NetObjectList<Item> chestItems = (chest.SpecialChestType == Chest.SpecialChestTypes.MiniShippingBin || chest.SpecialChestType == Chest.SpecialChestTypes.JunimoChest)
+                        ? chest.GetItemsForPlayer(who.UniqueMultiplayerID)
+                        : chest.items;
+
+                // Fill chest stacks with player inventory items
+                foreach (Item chestItem in chestItems)
+                {
+                    if (chestItem is null)
+                    {
+                        continue;
+                    }
+
+                    IList<Item> playerInventory = who.Items;
+
+                    foreach (Item playerItem in playerInventory)
+                    {
+                        if (playerItem is null || !playerItem.canStackWith(chestItem))
+                        {
+                            continue;
+                        }
+
+                        if (ModEntry.Config.IsEnableFavoriteItems && ConvenientInventory.FavoriteItemSlots[playerInventory.IndexOf(playerItem)])
+                        {
+                            // Skip favorited items
+                            continue;
+                        }
+
+                        int beforeStack = playerItem.Stack;
+                        playerItem.Stack = chestItem.addToStack(playerItem);
+                        bool movedAtLeastOne = beforeStack != playerItem.Stack;
+
+                        movedAtLeastOneTotal = movedAtLeastOneTotal || movedAtLeastOne;
+
+                        if (movedAtLeastOne && playerItem.Stack == 0)
+                        {
+                            who.removeItemFromInventory(playerItem);
+                        }
+
+                        if (chestItem.Stack == chestItem.maximumStackSize())
+                        {
+                            if (ModEntry.Config.IsQuickStackOverflowItems)
+                            {
+                                stackOverflowItems.Add(chestItem.getOne());
+                            }
+
+                            break;
+                        }
+                    }
+                }
+
+                // Add overflow stacks to chest when applicable
+                if (ModEntry.Config.IsQuickStackOverflowItems && chestItems.Count < chest.GetActualCapacity())
+                {
+                    IList<Item> playerInventory = who.Items;
+
+                    foreach (Item stackOverflowItem in stackOverflowItems)
+                    {
+                        if (stackOverflowItem is null)
+                        {
+                            continue;
+                        }
+
+                        foreach (Item playerItem in playerInventory)
+                        {
+                            if (playerItem is null || !playerItem.canStackWith(stackOverflowItem))
+                            {
+                                continue;
+                            }
+
+                            if (ModEntry.Config.IsEnableFavoriteItems && ConvenientInventory.FavoriteItemSlots[playerInventory.IndexOf(playerItem)])
+                            {
+                                // Skip favorited items
+                                continue;
+                            }
+
+                            int beforeStack = playerItem.Stack;
+                            Item leftoverItem = chest.addItem(playerItem);
+                            bool movedAtLeastOne = leftoverItem is null || beforeStack != leftoverItem.Stack;
+
+                            movedAtLeastOneTotal = movedAtLeastOneTotal || movedAtLeastOne;
+
+                            if (leftoverItem is null)
+                            {
+                                who.removeItemFromInventory(playerItem);
+                            }
+                        }
+                    }
+                }
+            }
+
+            Game1.playSound(movedAtLeastOneTotal ? "Ship" : "cancel");
+
+            return movedAtLeastOneTotal;
+        }
+
+        public static List<Chest> GetChestsAroundFarmer(Farmer who, int range, bool sorted = false)
+        {
+            if (who is null)
+            {
+                return new List<Chest>();
+            }
+
+            Vector2 farmerPosition = who.getStandingPosition();
+            Point farmerTileLocation = who.getTileLocationPoint();
+            GameLocation gameLocation = who.currentLocation;
+
+            return sorted
+                ? GetNearbyChestsWithDistance(farmerPosition, range, gameLocation).OrderBy(x => x.Distance).Select(x => x.Chest).ToList()
+                : GetNearbyChests(farmerTileLocation, range, gameLocation);
+        }
+
+        public static List<TypedChest> GetTypedChestsAroundFarmer(Farmer who, int range, bool sorted = false)
+        {
+            if (who is null)
+            {
+                return new List<TypedChest>();
+            }
+
+            Vector2 farmerPosition = who.getStandingPosition();
+            Point farmerTileLocation = who.getTileLocationPoint();
+            GameLocation gameLocation = who.currentLocation;
+
+            return sorted
+                ? GetNearbyTypedChestsWithDistance(farmerPosition, range, gameLocation).OrderBy(x => x.Distance).Select(x => x.TypedChest).ToList()
+                : GetNearbyTypedChests(farmerTileLocation, range, gameLocation);
+        }
+
+        // From origin, return all nearby chests, including the point-distance from their tile-center to origin, within a given square range.
+        private static List<ChestWithDistance> GetNearbyChestsWithDistance(Vector2 origin, int range, GameLocation gameLocation)
+        {
+            var dChests = new List<ChestWithDistance>((2 * range + 1) * (2 * range + 1));
+            Vector2 originTileCenterPosition = GetTileCenterPosition(GetTileLocation(origin));
+            Vector2 tileLocation = Vector2.Zero;
+            int tx, ty, dx, dy;
+
+            // Chests (includes mini fridge, stone chest, mini shipping bin, junimo chest, ...)
+            for (int x = -range; x <= range; x++)
+            {
+                for (int y = -range; y <= range; y++)
+                {
+                    tx = (int)originTileCenterPosition.X + (x * Game1.tileSize);
+                    ty = (int)originTileCenterPosition.Y + (y * Game1.tileSize);
+
+                    tileLocation.X = tx / Game1.tileSize;
+                    tileLocation.Y = ty / Game1.tileSize;
+
+                    if (gameLocation.objects.TryGetValue(tileLocation, out StardewValley.Object obj) && obj is Chest chest)
+                    {
+                        // Make sure chest is not in-use by another player (easy fix to avoid item deletion)
+                        if (chest.GetMutex().IsLocked())
+                        {
+                            continue;
+                        }
+
+                        dx = tx - (int)origin.X;
+                        dy = ty - (int)origin.Y;
+
+                        dChests.Add(new ChestWithDistance(chest, Math.Sqrt(dx * dx + dy * dy)));
+                    }
+                }
+            }
+
+            // Kitchen fridge
+            if (gameLocation is FarmHouse farmHouse && farmHouse.upgradeLevel > 0)  // Kitchen only exists when upgradeLevel > 0
+            {
+                Vector2 fridgeTileCenterPosition = GetTileCenterPosition(farmHouse.fridgePosition);
+
+                if (IsPositionWithinRange(origin, fridgeTileCenterPosition, range))
+                {
+                    if (farmHouse.fridge.Value != null && !farmHouse.fridge.Value.GetMutex().IsLocked())
+                    {
+                        dx = (int)fridgeTileCenterPosition.X - (int)origin.X;
+                        dy = (int)fridgeTileCenterPosition.Y - (int)origin.Y;
+
+                        dChests.Add(new ChestWithDistance(farmHouse.fridge.Value, Math.Sqrt(dx * dx + dy * dy)));
+                    }
+                }
+            }
+
+            // Island kitchen fridge
+            if (gameLocation is IslandFarmHouse islandFarmHouse)
+            {
+                Vector2 fridgeTileCenterPosition = GetTileCenterPosition(islandFarmHouse.fridgePosition);
+
+                if (IsPositionWithinRange(origin, fridgeTileCenterPosition, range))
+                {
+                    if (islandFarmHouse.fridge.Value != null && !islandFarmHouse.fridge.Value.GetMutex().IsLocked())
+                    {
+                        dx = (int)fridgeTileCenterPosition.X - (int)origin.X;
+                        dy = (int)fridgeTileCenterPosition.Y - (int)origin.Y;
+
+                        dChests.Add(new ChestWithDistance(islandFarmHouse.fridge.Value, Math.Sqrt(dx * dx + dy * dy)));
+                    }
+                }
+            }
+
+            // Buildings
+            if (ModEntry.Config.IsQuickStackIntoBuildingsWithInventories)
+            {
+                if (gameLocation is BuildableGameLocation buildableGameLocation)
+                {
+                    foreach (Building building in buildableGameLocation.buildings)
+                    {
+                        Vector2 buildingTileCenterPosition = GetTileCenterPosition(building.tileX.Value, building.tileY.Value);
+
+                        if (IsPositionWithinRange(origin, buildingTileCenterPosition, range))
+                        {
+                            if (building is JunimoHut junimoHut)
+                            {
+                                if (junimoHut.output.Value.GetMutex().IsLocked())
+                                {
+                                    continue;
+                                }
+
+                                dx = (int)buildingTileCenterPosition.X - (int)origin.X;
+                                dy = (int)buildingTileCenterPosition.Y - (int)origin.Y;
+
+                                dChests.Add(new ChestWithDistance(junimoHut.output.Value, Math.Sqrt(dx * dx + dy * dy)));
+                            }
+                            else if (building is Mill mill)
+                            {
+                                if (mill.isUnderConstruction() || mill.input.Value.GetMutex().IsLocked())
+                                {
+                                    continue;
+                                }
+
+                                dx = (int)buildingTileCenterPosition.X - (int)origin.X;
+                                dy = (int)buildingTileCenterPosition.Y - (int)origin.Y;
+
+                                dChests.Add(new ChestWithDistance(mill.input.Value, Math.Sqrt(dx * dx + dy * dy)));
+                            }
+                        }
+                    }
+                }
+            }
+
+            return dChests;
+        }
+
+        private static List<TypedChestWithDistance> GetNearbyTypedChestsWithDistance(Vector2 origin, int range, GameLocation gameLocation)
+        {
+            var tdChests = new List<TypedChestWithDistance>((2 * range + 1) * (2 * range + 1));
+            Vector2 originTileCenterPosition = GetTileCenterPosition(GetTileLocation(origin));
+            Vector2 tileLocation = Vector2.Zero;
+            int tx, ty, dx, dy;
+
+            // Chests (includes mini fridge, stone chest, mini shipping bin, junimo chest, ...)
+            for (int x = -range; x <= range; x++)
+            {
+                for (int y = -range; y <= range; y++)
+                {
+                    tx = (int)originTileCenterPosition.X + (x * Game1.tileSize);
+                    ty = (int)originTileCenterPosition.Y + (y * Game1.tileSize);
+
+                    tileLocation.X = tx / Game1.tileSize;
+                    tileLocation.Y = ty / Game1.tileSize;
+
+                    if (gameLocation.objects.TryGetValue(tileLocation, out StardewValley.Object obj) && obj is Chest chest)
+                    {
+                        // Make sure chest is not in-use by another player (easy fix to avoid item deletion)
+                        if (chest.GetMutex().IsLocked())
+                        {
+                            continue;
+                        }
+
+                        dx = tx - (int)origin.X;
+                        dy = ty - (int)origin.Y;
+
+                        ChestType chestType = TypedChest.GetChestType(chest);
+
+                        var typedChest = new TypedChest(chest, chestType);
+
+                        tdChests.Add(new TypedChestWithDistance(typedChest, Math.Sqrt(dx * dx + dy * dy)));
+                    }
+                }
+            }
+
+            // Kitchen fridge
+            if (gameLocation is FarmHouse farmHouse && farmHouse.upgradeLevel > 0)  // Kitchen only exists when upgradeLevel > 0
+            {
+                Vector2 fridgeTileCenterPosition = GetTileCenterPosition(farmHouse.fridgePosition);
+
+                if (IsPositionWithinRange(origin, fridgeTileCenterPosition, range))
+                {
+                    if (farmHouse.fridge.Value != null && !farmHouse.fridge.Value.GetMutex().IsLocked())
+                    {
+                        dx = (int)fridgeTileCenterPosition.X - (int)origin.X;
+                        dy = (int)fridgeTileCenterPosition.Y - (int)origin.Y;
+
+                        var typedChest = new TypedChest(farmHouse.fridge.Value, ChestType.Fridge);
+
+                        tdChests.Add(new TypedChestWithDistance(typedChest, Math.Sqrt(dx * dx + dy * dy)));
+                    }
+                }
+            }
+
+            // Island kitchen fridge
+            if (gameLocation is IslandFarmHouse islandFarmHouse)
+            {
+                Vector2 fridgeTileCenterPosition = GetTileCenterPosition(islandFarmHouse.fridgePosition);
+
+                if (IsPositionWithinRange(origin, fridgeTileCenterPosition, range))
+                {
+                    if (islandFarmHouse.fridge.Value != null && !islandFarmHouse.fridge.Value.GetMutex().IsLocked())
+                    {
+                        dx = (int)fridgeTileCenterPosition.X - (int)origin.X;
+                        dy = (int)fridgeTileCenterPosition.Y - (int)origin.Y;
+
+                        var typedChest = new TypedChest(islandFarmHouse.fridge.Value, ChestType.Fridge);
+
+                        tdChests.Add(new TypedChestWithDistance(typedChest, Math.Sqrt(dx * dx + dy * dy)));
+                    }
+                }
+            }
+
+            // Buildings
+            if (ModEntry.Config.IsQuickStackIntoBuildingsWithInventories)
+            {
+                if (gameLocation is BuildableGameLocation buildableGameLocation)
+                {
+                    foreach (Building building in buildableGameLocation.buildings)
+                    {
+                        Vector2 buildingTileCenterPosition = GetTileCenterPosition(building.tileX.Value, building.tileY.Value);
+
+                        if (IsPositionWithinRange(origin, buildingTileCenterPosition, range))
+                        {
+                            if (building is JunimoHut junimoHut)
+                            {
+                                if (junimoHut.output.Value.GetMutex().IsLocked())
+                                {
+                                    continue;
+                                }
+
+                                dx = (int)buildingTileCenterPosition.X - (int)origin.X;
+                                dy = (int)buildingTileCenterPosition.Y - (int)origin.Y;
+
+                                var typedChest = new TypedChest(junimoHut.output.Value, ChestType.JunimoHut);
+
+                                tdChests.Add(new TypedChestWithDistance(typedChest, Math.Sqrt(dx * dx + dy * dy)));
+                            }
+                            else if (building is Mill mill)
+                            {
+                                if (mill.isUnderConstruction() || mill.input.Value.GetMutex().IsLocked())
+                                {
+                                    continue;
+                                }
+
+                                dx = (int)buildingTileCenterPosition.X - (int)origin.X;
+                                dy = (int)buildingTileCenterPosition.Y - (int)origin.Y;
+
+                                var typedChest = new TypedChest(mill.input.Value, ChestType.Mill);
+
+                                tdChests.Add(new TypedChestWithDistance(typedChest, Math.Sqrt(dx * dx + dy * dy)));
+                            }
+                        }
+                    }
+                }
+            }
+
+            return tdChests;
+        }
+
+        private static List<Chest> GetNearbyChests(Point originTile, int range, GameLocation gameLocation)
+        {
+            var chests = new List<Chest>((2 * range + 1) * (2 * range + 1));
+
+            // Chests
+            for (int dx = -range; dx <= range; dx++)
+            {
+                for (int dy = -range; dy <= range; dy++)
+                {
+                    Vector2 tileLocation = new Vector2(originTile.X + dx, originTile.Y + dy);
+
+                    if (gameLocation.objects.TryGetValue(tileLocation, out StardewValley.Object obj) && obj is Chest chest)
+                    {
+                        if (chest.GetMutex().IsLocked())
+                        {
+                            continue;
+                        }
+
+                        chests.Add(chest);
+                    }
+                }
+            }
+
+            // Kitchen fridge
+            if (gameLocation is FarmHouse farmHouse && farmHouse.upgradeLevel >= 1) //Lvl 1,2,3 is where you have fridge upgrade
+            {
+                Point kitchenStandingSpot = farmHouse.getKitchenStandingSpot();
+                Point fridgeTileLocation = new Point(kitchenStandingSpot.X + 2, kitchenStandingSpot.Y - 1); //Fridge spot relative to kitchen spot
+
+                if (IsTileWithinRange(originTile, fridgeTileLocation, range))
+                {
+                    if (farmHouse.fridge.Value != null && !farmHouse.fridge.Value.GetMutex().IsLocked())
+                    {
+                        chests.Add(farmHouse.fridge.Value);
+                    }
+                }
+            }
+
+            // Island kitchen fridge
+            if (gameLocation is IslandFarmHouse islandFarmHouse)
+            {
+                Point fridgeTileLocation = islandFarmHouse.fridgePosition;
+
+                if (IsTileWithinRange(originTile, fridgeTileLocation, range))
+                {
+                    if (islandFarmHouse.fridge.Value != null && !islandFarmHouse.fridge.Value.GetMutex().IsLocked())
+                    {
+                        chests.Add(islandFarmHouse.fridge.Value);
+                    }
+                }
+            }
+
+            // Buildings
+            if (ModEntry.Config.IsQuickStackIntoBuildingsWithInventories)
+            {
+                if (gameLocation is BuildableGameLocation buildableGameLocation)
+                {
+                    foreach (Building building in buildableGameLocation.buildings)
+                    {
+                        if (IsTileWithinRange(originTile, building.tileX.Value, building.tileY.Value, range))
+                        {
+                            if (building is JunimoHut junimoHut)
+                            {
+                                if (junimoHut.output.Value.GetMutex().IsLocked())
+                                {
+                                    continue;
+                                }
+
+                                chests.Add(junimoHut.output.Value);
+                            }
+                            else if (building is Mill mill)
+                            {
+                                if (mill.input.Value.GetMutex().IsLocked())
+                                {
+                                    continue;
+                                }
+
+                                chests.Add(mill.input.Value);
+                            }
+                        }
+                    }
+                }
+            }
+
+            return chests;
+        }
+
+        private static List<TypedChest> GetNearbyTypedChests(Point originTile, int range, GameLocation gameLocation)
+        {
+            var tChests = new List<TypedChest>((2 * range + 1) * (2 * range + 1));
+
+            // Chests
+            for (int dx = -range; dx <= range; dx++)
+            {
+                for (int dy = -range; dy <= range; dy++)
+                {
+                    Vector2 tileLocation = new Vector2(originTile.X + dx, originTile.Y + dy);
+
+                    if (gameLocation.objects.TryGetValue(tileLocation, out StardewValley.Object obj) && obj is Chest chest)
+                    {
+                        if (chest.GetMutex().IsLocked())
+                        {
+                            continue;
+                        }
+
+                        ChestType chestType = TypedChest.GetChestType(chest);
+
+                        tChests.Add(new TypedChest(chest, chestType));
+                    }
+                }
+            }
+
+            // Kitchen fridge
+            if (gameLocation is FarmHouse farmHouse && farmHouse.upgradeLevel >= 1) //Lvl 1,2,3 is where you have fridge upgrade
+            {
+                Point kitchenStandingSpot = farmHouse.getKitchenStandingSpot();
+                Point fridgeTileLocation = new Point(kitchenStandingSpot.X + 2, kitchenStandingSpot.Y - 1); //Fridge spot relative to kitchen spot
+
+                if (IsTileWithinRange(originTile, fridgeTileLocation, range))
+                {
+                    if (farmHouse.fridge.Value != null && !farmHouse.fridge.Value.GetMutex().IsLocked())
+                    {
+                        tChests.Add(new TypedChest(farmHouse.fridge.Value, ChestType.Fridge));
+                    }
+                }
+            }
+
+            // Island kitchen fridge
+            if (gameLocation is IslandFarmHouse islandFarmHouse)
+            {
+                Point fridgeTileLocation = islandFarmHouse.fridgePosition;
+
+                if (IsTileWithinRange(originTile, fridgeTileLocation, range))
+                {
+                    if (islandFarmHouse.fridge.Value != null && !islandFarmHouse.fridge.Value.GetMutex().IsLocked())
+                    {
+                        tChests.Add(new TypedChest(islandFarmHouse.fridge.Value, ChestType.Fridge));
+                    }
+                }
+            }
+
+            // Buildings
+            if (ModEntry.Config.IsQuickStackIntoBuildingsWithInventories)
+            {
+                if (gameLocation is BuildableGameLocation buildableGameLocation)
+                {
+                    foreach (Building building in buildableGameLocation.buildings)
+                    {
+                        if (IsTileWithinRange(originTile, building.tileX.Value, building.tileY.Value, range))
+                        {
+                            if (building is JunimoHut junimoHut)
+                            {
+                                if (junimoHut.output.Value.GetMutex().IsLocked())
+                                {
+                                    continue;
+                                }
+
+                                tChests.Add(new TypedChest(junimoHut.output.Value, ChestType.JunimoHut));
+                            }
+                            else if (building is Mill mill)
+                            {
+                                if (mill.input.Value.GetMutex().IsLocked())
+                                {
+                                    continue;
+                                }
+
+                                tChests.Add(new TypedChest(mill.input.Value, ChestType.Mill));
+                            }
+                        }
+                    }
+                }
+            }
+
+            return tChests;
+        }
+
+        private static Point GetTileLocation(Vector2 position)
+        {
+            return new Point(
+                (int)position.X / Game1.tileSize,
+                (int)position.Y / Game1.tileSize);
+        }
+
+        private static Vector2 GetTileCenterPosition(Point tileLocation)
+        {
+            return new Vector2(
+                (tileLocation.X * Game1.tileSize) + (Game1.tileSize / 2),
+                (tileLocation.Y * Game1.tileSize) + (Game1.tileSize / 2));
+        }
+
+        private static Vector2 GetTileCenterPosition(int tileX, int tileY)
+        {
+            return new Vector2(
+                (tileX * Game1.tileSize) + (Game1.tileSize / 2),
+                (tileY * Game1.tileSize) + (Game1.tileSize / 2));
+        }
+
+        private static bool IsTileWithinRange(Point origin, Point target, int range)
+        {
+            return Math.Abs(origin.X - target.X) <= range && Math.Abs(origin.Y - target.Y) <= range;
+        }
+
+        private static bool IsTileWithinRange(Point origin, int targetX, int targetY, int range)
+        {
+            return Math.Abs(origin.X - targetX) <= range && Math.Abs(origin.Y - targetY) <= range;
+        }
+
+        private static bool IsPositionWithinRange(Vector2 origin, Vector2 target, int range)
+        {
+            return Math.Abs(origin.X - target.X) <= (range * Game1.tileSize) && Math.Abs(origin.Y - target.Y) <= (range * Game1.tileSize);
+        }
+    }
 }

--- a/ConvenientInventory/ConvenientInventory/README.md
+++ b/ConvenientInventory/ConvenientInventory/README.md
@@ -1,0 +1,43 @@
+NexusMods link: https://www.nexusmods.com/stardewvalley/mods/10384
+
+# Convenient Inventory
+Adds convenience features to the player's inventory, such as quick stack to nearby chests and favorited items.
+
+## Preview
+One of the most tedious parts of any game is inventory management, and this is especially true in Stardew Valley. Every day, whether it be from farming produce, mining rewards, or freshly caught fish, you will be emptying out your backpack to store items into chests on your farm. After a while, this process becomes all too familiar: open chest, deposit items, close chest, open chest, deposit items, close chest, open chest, deposit items, close chest, ... etc.
+
+What if you could stow away all the items taking up space in your backpack, instantly, while keeping the important ones?
+
+![](https://imgur.com/R4QWKVI.gif)
+
+## Features
+#### Quick Stack to Nearby Chests
+Click the new "Quick Stack to Nearby Chests" button in the player's inventory UI to quickly deposit items into chests within a nearby range.
+
+#### Favorite Items
+Hold the favorite-hotkey (Left Alt, by default) and select items in the player's inventory to favorite them.
+
+Favorited items are prevented from:
+ - Being quick stacked
+ - Being trashed
+ - Being dropped
+ - Being considered when using the "Organize" button in the player's inventory
+ - Being considered when using the "Add to Existing Stacks" button in a chest
+
+## Config
+ - **IsEnableQuickStack**: If enabled, adds a "Quick Stack To Nearby Chests" button to your inventory menu. Pressing this button will stack items from your inventory to any nearby chests which contain that item.
+ - **QuickStackRange**: How many tiles away from the player to search for nearby chests.
+ - **IsQuickStackIntoBuildingsWithInventories**: If enabled, nearby buildings with inventories (such as Mills or Junimo Huts) will also be checked when quick stacking.
+ - **IsQuickStackOverflowItems**: If enabled, quick stack will place as many items as possible into chests which contain that item, rather than just a single stack.
+ - **IsQuickStackTooltipDrawNearbyChests**: If enabled, hovering over the quick stack button will show a preview of all nearby chests, ordered by distance.
+ - **IsEnableFavoriteItems**: If enabled, items in your inventory can be favorited. Favorited items will be ignored when stacking into chests.
+ - **FavoriteItemsHighlightTextureChoice**: Choose your preferred texture style for highlighting favorited items in your inventory.
+   - ( 0: ![](https://i.imgur.com/fTMl0FT.png),  1: ![](https://i.imgur.com/NTlia1R.png),  2: ![](https://i.imgur.com/QGztt8Q.png),  3: ![](https://i.imgur.com/MBG2A6e.png),  4: ![](https://i.imgur.com/rZqklnN.png),  5: ![](https://i.imgur.com/FvKpyZV.png) )
+ - FavoriteItemsKeyboardHotkey: Hold this key when selecting an item to favorite it.
+ - FavoriteItemsControllerHotkey: Hold this button when selecting an item to favorite it. (For controller support)
+
+## Compatibility
+ - Supports single player, split-screen local multiplayer, and online multiplayer.
+ - Supports controllers by using the left-stick button (configurable) for favoriting.
+ - Supports [Generic Mod Config Menu](https://www.nexusmods.com/stardewvalley/mods/5098) for in-game config editing.
+ - Supports [Bigger Backpack](https://www.nexusmods.com/stardewvalley/mods/1845) and other inventory expansion mods (as of version 1.1.0).

--- a/ConvenientInventory/ConvenientInventory/README.md
+++ b/ConvenientInventory/ConvenientInventory/README.md
@@ -1,5 +1,4 @@
 TO DO:
- - Add hotkey for "Organize" button via opt-in config option.
  - Add new opt-in config option that adds a left-to-right warp with the gamepad cursor in inventory page.
  - Add new opt-in config option that allows quick stacking of items without checking quality.
  - Support compatibility with "Vertical Toolbar" mod.
@@ -14,6 +13,8 @@ TO DO:
  DONE:
  - Fix assets directory issue due to capitalization.
  - Add hotkey for quick stack via opt-in config option.
+ - (X) Add hotkey for "Organize" button via opt-in config option.
+   - No need for this, as base game already has a hotkey! When in your inventory menu, press the controller's "back" button to organize inventory.
 
  ---
 

--- a/ConvenientInventory/ConvenientInventory/README.md
+++ b/ConvenientInventory/ConvenientInventory/README.md
@@ -1,3 +1,22 @@
+TO DO:
+ - Add hotkey for "Organize" button via opt-in config option.
+ - Add new opt-in config option that adds a left-to-right warp with the gamepad cursor in inventory page.
+ - Add new opt-in config option that allows quick stacking of items without checking quality.
+ - Support compatibility with "Vertical Toolbar" mod.
+   - If possible, extend compatibility for all mods that modify the player's inventory size, even if in (what I'm presuming to be) irregular ways like this one.
+ - Support compatibility with mods that add storage objects, such as
+   - Mega Storage
+   - Expanded Storage
+   - Storage Variety
+ - Re-investigate feasability of preventing favorited items from being placed in the shipping bin.
+ - tails618: "community center bundles in the inventory is gone... am I missing something?". Validate if this is true.
+
+ DONE:
+ - Fix assets directory issue due to capitalization.
+ - Add hotkey for quick stack via opt-in config option.
+
+ ---
+
 NexusMods link: https://www.nexusmods.com/stardewvalley/mods/10384
 
 # Convenient Inventory
@@ -27,6 +46,9 @@ Favorited items are prevented from:
 ## Config
  - **IsEnableQuickStack**: If enabled, adds a "Quick Stack To Nearby Chests" button to your inventory menu. Pressing this button will stack items from your inventory to any nearby chests which contain that item.
  - **QuickStackRange**: How many tiles away from the player to search for nearby chests.
+ - **IsEnableQuickStackHotkey**: If enabled, pressing either of the quick stack hotkeys specified below will quick stack your items, even outside of your inventory menu.
+ - **QuickStackKeyboardHotkey**: Press this key to quick stack your items.
+ - **QuickStackControllerHotkey**: Press this button to quick stack your items.
  - **IsQuickStackIntoBuildingsWithInventories**: If enabled, nearby buildings with inventories (such as Mills or Junimo Huts) will also be checked when quick stacking.
  - **IsQuickStackOverflowItems**: If enabled, quick stack will place as many items as possible into chests which contain that item, rather than just a single stack.
  - **IsQuickStackTooltipDrawNearbyChests**: If enabled, hovering over the quick stack button will show a preview of all nearby chests, ordered by distance.

--- a/ConvenientInventory/ConvenientInventory/README.md
+++ b/ConvenientInventory/ConvenientInventory/README.md
@@ -33,8 +33,8 @@ Favorited items are prevented from:
  - **IsEnableFavoriteItems**: If enabled, items in your inventory can be favorited. Favorited items will be ignored when stacking into chests.
  - **FavoriteItemsHighlightTextureChoice**: Choose your preferred texture style for highlighting favorited items in your inventory.
    - ( 0: ![](https://i.imgur.com/fTMl0FT.png),  1: ![](https://i.imgur.com/NTlia1R.png),  2: ![](https://i.imgur.com/QGztt8Q.png),  3: ![](https://i.imgur.com/MBG2A6e.png),  4: ![](https://i.imgur.com/rZqklnN.png),  5: ![](https://i.imgur.com/FvKpyZV.png) )
- - FavoriteItemsKeyboardHotkey: Hold this key when selecting an item to favorite it.
- - FavoriteItemsControllerHotkey: Hold this button when selecting an item to favorite it. (For controller support)
+ - **FavoriteItemsKeyboardHotkey**: Hold this key when selecting an item to favorite it.
+ - **FavoriteItemsControllerHotkey**: Hold this button when selecting an item to favorite it. (For controller support)
 
 ## Compatibility
  - Supports single player, split-screen local multiplayer, and online multiplayer.

--- a/ConvenientInventory/ConvenientInventory/TypedChests.cs
+++ b/ConvenientInventory/ConvenientInventory/TypedChests.cs
@@ -5,187 +5,187 @@ using StardewValley.Objects;
 
 namespace ConvenientInventory.TypedChests
 {
-	public enum ChestType
-	{
-		Normal,
-		Stone,
-		Fridge,
-		MiniFridge,
-		Mill,
-		JunimoHut,
-		Special
-	}
+    public enum ChestType
+    {
+        Normal,
+        Stone,
+        Fridge,
+        MiniFridge,
+        Mill,
+        JunimoHut,
+        Special
+    }
 
-	public class TypedChest
-	{
-		public Chest Chest { get; private set; }
+    public class TypedChest
+    {
+        public Chest Chest { get; private set; }
 
-		public ChestType ChestType { get; private set; }
+        public ChestType ChestType { get; private set; }
 
-		public TypedChest(Chest chest, ChestType chestType)
-		{
-			Chest = chest;
-			ChestType = chestType;
-		}
-
-		public static ChestType GetChestType(Chest chest)
-		{
-			if (chest.SpecialChestType != Chest.SpecialChestTypes.None)
-			{
-				return ChestType.Special;
-			}
-
-			switch (chest.ParentSheetIndex)
-			{
-				case 130:
-				default:
-					return ChestType.Normal;
-				case 232:
-					return ChestType.Stone;
-				case 216:
-					return ChestType.MiniFridge;
-			}
-		}
-
-		public static bool IsBuildingChestType(ChestType chestType)
+        public TypedChest(Chest chest, ChestType chestType)
         {
-			return chestType == ChestType.Mill || chestType == ChestType.JunimoHut;
+            Chest = chest;
+            ChestType = chestType;
         }
 
-		/// <summary>Returns the number of tooltip position indexes skipped while drawing (due to buildings occupying > 1 index).</summary>
-		public int DrawInToolTip(SpriteBatch spriteBatch, Point toolTipPosition, int posIndex)
-		{
-			int newPosIndex;
+        public static ChestType GetChestType(Chest chest)
+        {
+            if (chest.SpecialChestType != Chest.SpecialChestTypes.None)
+            {
+                return ChestType.Special;
+            }
 
-			int x = toolTipPosition.X + 20 + 46 * (posIndex % 8);
-			int y = toolTipPosition.Y + 40 + 52 * (posIndex / 8);
+            switch (chest.ParentSheetIndex)
+            {
+                case 130:
+                default:
+                    return ChestType.Normal;
+                case 232:
+                    return ChestType.Stone;
+                case 216:
+                    return ChestType.MiniFridge;
+            }
+        }
 
-			switch (this.ChestType)
-			{
-				case ChestType.Normal:
-					spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
-						new Vector2(x, y),
-						Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, !this.Chest.playerChoiceColor.Value.Equals(Color.Black) ? 168 : this.Chest.ParentSheetIndex, 16, 32),
-						this.Chest.playerChoiceColor.Value.Equals(Color.Black) ? this.Chest.Tint : this.Chest.playerChoiceColor.Value,
-						0f, Vector2.Zero, 2f, SpriteEffects.None, 1f
-					);
-					spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
-						new Vector2(x, y + 42),
-						new Rectangle(0, 168 / 8 * 32 + 53, 16, 11),
-						Color.White,
-						0f, Vector2.Zero, 2f, SpriteEffects.None, 1f - 1E-05f
-					);
-					spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
-						new Vector2(x, y),
-						Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, this.Chest.startingLidFrame.Value + 46, 16, 32),
-						Color.White,
-						0f, Vector2.Zero, 2f, SpriteEffects.None, 1f - 2E-05f
-					);
+        public static bool IsBuildingChestType(ChestType chestType)
+        {
+            return chestType == ChestType.Mill || chestType == ChestType.JunimoHut;
+        }
 
-					return 0;
-				case ChestType.Stone:
-					spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
-						new Vector2(x, y),
-						Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, this.Chest.ParentSheetIndex, 16, 32),
-						this.Chest.playerChoiceColor.Value.Equals(Color.Black) ? this.Chest.Tint : this.Chest.playerChoiceColor.Value,
-						0f, Vector2.Zero, 2f, SpriteEffects.None, 1f
-					);
-					spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
-						new Vector2(x, y + 42),
-						new Rectangle(0, this.Chest.ParentSheetIndex / 8 * 32 + 53, 16, 11),
-						Color.White,
-						0f, Vector2.Zero, 2f, SpriteEffects.None, 1f - 1E-05f
-					);
-					spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
-						new Vector2(x, y),
-						Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, this.Chest.startingLidFrame.Value + 8, 16, 32),
-						Color.White,
-						0f, Vector2.Zero, 2f, SpriteEffects.None, 1f - 2E-05f
-					);
+        /// <summary>Returns the number of tooltip position indexes skipped while drawing (due to buildings occupying > 1 index).</summary>
+        public int DrawInToolTip(SpriteBatch spriteBatch, Point toolTipPosition, int posIndex)
+        {
+            int newPosIndex;
 
-					return 0;
-				case ChestType.Fridge:
-					if (Game1.currentLocation is StardewValley.Locations.FarmHouse)
-					{
-						spriteBatch.Draw(CachedTextures.FarmHouse,
-							new Vector2(x, y + 3),
-							new Rectangle(16 * 5, 48 * 4 + 13, 16, 35),
-							Color.White,
-							0f, Vector2.Zero, 1.75f, SpriteEffects.None, 1f
-						);
-					}
-					else
-					{
-						// Island house
-						spriteBatch.Draw(CachedTextures.FarmHouse,
-							new Vector2(x, y + 3),
-							new Rectangle(16 * 6, 48 * 6 + 29, 16, 35),
-							Color.White,
-							0f, Vector2.Zero, 1.75f, SpriteEffects.None, 1f
-						);
-					}
+            int x = toolTipPosition.X + 20 + 46 * (posIndex % 8);
+            int y = toolTipPosition.Y + 40 + 52 * (posIndex / 8);
 
-					return 0;
-				case ChestType.MiniFridge:
-					spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
-						new Vector2(x, y + 8),
-						Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, this.Chest.ParentSheetIndex, 16, 32),
-						Color.White,
-						0f, Vector2.Zero, 1.75f, SpriteEffects.None, 1f
-					);
+            switch (this.ChestType)
+            {
+                case ChestType.Normal:
+                    spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
+                        new Vector2(x, y),
+                        Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, !this.Chest.playerChoiceColor.Value.Equals(Color.Black) ? 168 : this.Chest.ParentSheetIndex, 16, 32),
+                        this.Chest.playerChoiceColor.Value.Equals(Color.Black) ? this.Chest.Tint : this.Chest.playerChoiceColor.Value,
+                        0f, Vector2.Zero, 2f, SpriteEffects.None, 1f
+                    );
+                    spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
+                        new Vector2(x, y + 42),
+                        new Rectangle(0, 168 / 8 * 32 + 53, 16, 11),
+                        Color.White,
+                        0f, Vector2.Zero, 2f, SpriteEffects.None, 1f - 1E-05f
+                    );
+                    spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
+                        new Vector2(x, y),
+                        Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, this.Chest.startingLidFrame.Value + 46, 16, 32),
+                        Color.White,
+                        0f, Vector2.Zero, 2f, SpriteEffects.None, 1f - 2E-05f
+                    );
 
-					return 0;
-				case ChestType.Mill:
-					newPosIndex = posIndex;
+                    return 0;
+                case ChestType.Stone:
+                    spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
+                        new Vector2(x, y),
+                        Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, this.Chest.ParentSheetIndex, 16, 32),
+                        this.Chest.playerChoiceColor.Value.Equals(Color.Black) ? this.Chest.Tint : this.Chest.playerChoiceColor.Value,
+                        0f, Vector2.Zero, 2f, SpriteEffects.None, 1f
+                    );
+                    spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
+                        new Vector2(x, y + 42),
+                        new Rectangle(0, this.Chest.ParentSheetIndex / 8 * 32 + 53, 16, 11),
+                        Color.White,
+                        0f, Vector2.Zero, 2f, SpriteEffects.None, 1f - 1E-05f
+                    );
+                    spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
+                        new Vector2(x, y),
+                        Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, this.Chest.startingLidFrame.Value + 8, 16, 32),
+                        Color.White,
+                        0f, Vector2.Zero, 2f, SpriteEffects.None, 1f - 2E-05f
+                    );
 
-					if (posIndex % 8 == 7)
-					{
-						newPosIndex++;
-						x = toolTipPosition.X + 20 + 46 * (newPosIndex % 8);
-						y = toolTipPosition.Y + 40 + 52 * (newPosIndex / 8);
-					}
+                    return 0;
+                case ChestType.Fridge:
+                    if (Game1.currentLocation is StardewValley.Locations.FarmHouse)
+                    {
+                        spriteBatch.Draw(CachedTextures.FarmHouse,
+                            new Vector2(x, y + 3),
+                            new Rectangle(16 * 5, 48 * 4 + 13, 16, 35),
+                            Color.White,
+                            0f, Vector2.Zero, 1.75f, SpriteEffects.None, 1f
+                        );
+                    }
+                    else
+                    {
+                        // Island house
+                        spriteBatch.Draw(CachedTextures.FarmHouse,
+                            new Vector2(x, y + 3),
+                            new Rectangle(16 * 6, 48 * 6 + 29, 16, 35),
+                            Color.White,
+                            0f, Vector2.Zero, 1.75f, SpriteEffects.None, 1f
+                        );
+                    }
 
-					spriteBatch.Draw(CachedTextures.Mill,
-						new Vector2(x + 8, y),
-						new Rectangle(0, 64, 64, 64),
-						Color.White,
-						0f, Vector2.Zero, 1f, SpriteEffects.None, 1f
-					);
+                    return 0;
+                case ChestType.MiniFridge:
+                    spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
+                        new Vector2(x, y + 8),
+                        Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, this.Chest.ParentSheetIndex, 16, 32),
+                        Color.White,
+                        0f, Vector2.Zero, 1.75f, SpriteEffects.None, 1f
+                    );
 
-					newPosIndex++;
+                    return 0;
+                case ChestType.Mill:
+                    newPosIndex = posIndex;
 
-					return newPosIndex - posIndex;
-				case ChestType.JunimoHut:
-					newPosIndex = posIndex;
+                    if (posIndex % 8 == 7)
+                    {
+                        newPosIndex++;
+                        x = toolTipPosition.X + 20 + 46 * (newPosIndex % 8);
+                        y = toolTipPosition.Y + 40 + 52 * (newPosIndex / 8);
+                    }
 
-					if (posIndex % 8 == 7)
-					{
-						newPosIndex++;
-						x = toolTipPosition.X + 20 + 46 * (newPosIndex % 8);
-						y = toolTipPosition.Y + 40 + 52 * (newPosIndex / 8);
-					}
+                    spriteBatch.Draw(CachedTextures.Mill,
+                        new Vector2(x + 8, y),
+                        new Rectangle(0, 64, 64, 64),
+                        Color.White,
+                        0f, Vector2.Zero, 1f, SpriteEffects.None, 1f
+                    );
 
-					spriteBatch.Draw(CachedTextures.JunimoHut,
-						new Vector2(x + 9, y - 16),
-						new Rectangle(Utility.getSeasonNumber(Game1.currentSeason) * 48, 0, 48, 64),
-						Color.White,
-						0f, Vector2.Zero, 1.25f, SpriteEffects.None, 1f
-					);
+                    newPosIndex++;
 
-					newPosIndex++;
+                    return newPosIndex - posIndex;
+                case ChestType.JunimoHut:
+                    newPosIndex = posIndex;
 
-					return newPosIndex - posIndex;
-				case ChestType.Special:
-				default:
-					spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
-						new Vector2(x, y),
-						Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, this.Chest.ParentSheetIndex, 16, 32),
-						Color.White,
-						0f, Vector2.Zero, 2f, SpriteEffects.None, 1f
-					);
+                    if (posIndex % 8 == 7)
+                    {
+                        newPosIndex++;
+                        x = toolTipPosition.X + 20 + 46 * (newPosIndex % 8);
+                        y = toolTipPosition.Y + 40 + 52 * (newPosIndex / 8);
+                    }
 
-					return 0;
-			}
-		}
-	}
+                    spriteBatch.Draw(CachedTextures.JunimoHut,
+                        new Vector2(x + 9, y - 16),
+                        new Rectangle(Utility.getSeasonNumber(Game1.currentSeason) * 48, 0, 48, 64),
+                        Color.White,
+                        0f, Vector2.Zero, 1.25f, SpriteEffects.None, 1f
+                    );
+
+                    newPosIndex++;
+
+                    return newPosIndex - posIndex;
+                case ChestType.Special:
+                default:
+                    spriteBatch.Draw(Game1.bigCraftableSpriteSheet,
+                        new Vector2(x, y),
+                        Game1.getSourceRectForStandardTileSheet(Game1.bigCraftableSpriteSheet, this.Chest.ParentSheetIndex, 16, 32),
+                        Color.White,
+                        0f, Vector2.Zero, 2f, SpriteEffects.None, 1f
+                    );
+
+                    return 0;
+            }
+        }
+    }
 }

--- a/ConvenientInventory/ConvenientInventory/manifest.json
+++ b/ConvenientInventory/ConvenientInventory/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "Name": "Convenient Inventory",
   "Author": "gaussfire",
-  "Version": "1.1.0",
+  "Version": "1.2.0",
   "Description": "Adds convenience features to the player's inventory, such as quick stack to nearby chests and favorited items.",
   "UniqueID": "gaussfire.ConvenientInventory",
   "EntryDll": "ConvenientInventory.dll",


### PR DESCRIPTION
Fixed directory "Assets" != "assets" issue.

Fixed resetting config to default causing config to not be able to be modified again during that play session.

Changed default favorite items controller hotkey from Left-Stick to Left-Shoulder.
 - Should be easier to press. (Also freed up a hotkey to be used for the quick stack hotkey)

Added hotkey for quick stack.
 - DISABLED by default.
 - Default hotkey: K (Left-Stick on controller)

Did NOT add controller hotkey for "Organize" button
 - No need for this, as base game already has a hotkey! When in your inventory menu, press the controller's "back" button to organize inventory.