### PR TITLE
Convenient Inventory: Add config option to enable or disable stacking into hoppers

### DIFF
--- a/ConvenientInventory/Compatibility/ApiHelper.cs
+++ b/ConvenientInventory/Compatibility/ApiHelper.cs
@@ -106,6 +106,14 @@ namespace ConvenientInventory.Compatibility
 
             api.AddBoolOption(
                 mod: modManifest,
+                getValue: () => config.IsQuickStackIntoHoppers,
+                setValue: value => config.IsQuickStackIntoHoppers = value,
+                name: () => helper.Translation.Get("ModConfigMenu.IsQuickStackIntoHoppers.Name"),
+                tooltip: () => helper.Translation.Get("ModConfigMenu.IsQuickStackIntoHoppers.Desc")
+            );
+
+            api.AddBoolOption(
+                mod: modManifest,
                 getValue: () => config.IsQuickStackOverflowItems,
                 setValue: value => config.IsQuickStackOverflowItems = value,
                 name: () => helper.Translation.Get("ModConfigMenu.IsQuickStackOverflowItems.Name"),

--- a/ConvenientInventory/ModConfig.cs
+++ b/ConvenientInventory/ModConfig.cs
@@ -14,6 +14,8 @@ namespace ConvenientInventory
 
         public bool IsQuickStackIntoDressers { get; set; } = true;
 
+        public bool IsQuickStackIntoHoppers { get; set; } = true;
+
         public bool IsQuickStackOverflowItems { get; set; } = true;
 
         public bool IsQuickStackTooltipDrawNearbyChests { get; set; } = true;

--- a/ConvenientInventory/QuickStack/QuickStackLogic.cs
+++ b/ConvenientInventory/QuickStack/QuickStackLogic.cs
@@ -31,6 +31,11 @@ namespace ConvenientInventory.QuickStack
                 quickStackAnimation = new(who);
             }
 
+            if (!ModEntry.Config.IsQuickStackIntoHoppers)
+            {
+                chests = chests.Where(chest => chest.ChestType != ChestType.Hopper).ToList();
+            }
+
             foreach (TypedChest typedChest in chests)
             {
                 Chest chest = typedChest.Chest;

--- a/ConvenientInventory/TypedChests/ChestType.cs
+++ b/ConvenientInventory/TypedChests/ChestType.cs
@@ -14,6 +14,7 @@
         Special,
         Package,
         Dresser,
-        Dungeon
+        Dungeon,
+        Hopper
     }
 }

--- a/ConvenientInventory/TypedChests/TypedChest.cs
+++ b/ConvenientInventory/TypedChests/TypedChest.cs
@@ -35,6 +35,11 @@ namespace ConvenientInventory.TypedChests
                 return chest.QualifiedItemId == "(BC)BigStoneChest" ? ChestType.BigStone : ChestType.BigNormal;
             }
 
+            if (chest.SpecialChestType == Chest.SpecialChestTypes.AutoLoader)
+            {
+                return ChestType.Hopper;
+            }
+
             if (chest.SpecialChestType != Chest.SpecialChestTypes.None)
             {
                 return ChestType.Special;

--- a/ConvenientInventory/i18n/default.json
+++ b/ConvenientInventory/i18n/default.json
@@ -31,6 +31,9 @@
   "ModConfigMenu.IsQuickStackIntoDressers.Name": "Quick stack into dressers?",
   "ModConfigMenu.IsQuickStackIntoDressers.Desc": "(Requires \"Quick stack overflow items?\" to be enabled.)\nIf enabled, nearby dressers will be considered when quick stacking.",
 
+  "ModConfigMenu.IsQuickStackIntoHoppers.Name": "Quick stack into hoppers?",
+  "ModConfigMenu.IsQuickStackIntoHoppers.Desc": "(Requires \"Quick stack overflow items?\" to be enabled.)\nIf enabled, nearby Hoppers will be considered when quick stacking.",
+
   "ModConfigMenu.IsQuickStackOverflowItems.Name": "Quick stack overflow items?",
   "ModConfigMenu.IsQuickStackOverflowItems.Desc": "If enabled, quick stack will place as many items as possible into chests which contain that item, rather than just a single stack.",
 


### PR DESCRIPTION

This PR adds a config option `IsQuickStackIntoHoppers` that allows players to control whether Convenient Inventory should stack items into hoppers. This addresses the issue where users may accidentally stash items into filtered hoppers (from [Filtered Chest Hopper Mod](https://www.nexusmods.com/stardewvalley/mods/21730)) unintentionally. I’ve tested this and confirmed proper exclusion when the flag is false.