### PR TITLE
Make Convenient Inventory code resilient to inventory sizes smaller than 12

### DIFF
--- a/ConvenientInventory/ConvenientInventory.cs
+++ b/ConvenientInventory/ConvenientInventory.cs
@@ -17,6 +17,8 @@ namespace ConvenientInventory
 {
     public static class ConvenientInventory
     {
+        private const int NumSlotsPerInventoryRow = 12;
+
         private static IReadOnlyList<TypedChest> NearbyTypedChests { get; set; }
 
         private static readonly PerScreen<ClickableTextureComponent> quickStackButton = new();
@@ -612,9 +614,9 @@ namespace ConvenientInventory
                 return true;
             }
 
-            if (clickPos >= NumberOfToolbarItems)
+            if (clickPos >= NumSlotsPerInventoryRow)
             {
-                for (int k = 0; k < NumberOfToolbarItems; k++)
+                for (int k = 0; k < NumSlotsPerInventoryRow; k++)
                 {
                     if (Game1.player.Items[k] == null || Game1.player.Items[k].canStackWith(item))
                     {
@@ -626,7 +628,7 @@ namespace ConvenientInventory
             }
             else
             {
-                for (int j = NumberOfToolbarItems; j < Game1.player.Items.Count; j++)
+                for (int j = NumSlotsPerInventoryRow; j < Game1.player.Items.Count; j++)
                 {
                     if (Game1.player.Items[j] == null || Game1.player.Items[j].canStackWith(item))
                     {
@@ -699,7 +701,7 @@ namespace ConvenientInventory
         /// </summary>
         public static void ShiftToolbar(bool right)
         {
-            RotateArray(FavoriteItemSlots, NumberOfToolbarItems, right);
+            RotateArray(FavoriteItemSlots, NumSlotsPerInventoryRow, right);
         }
 
         private static void RotateArray(bool[] arr, int count, bool right)
@@ -973,7 +975,8 @@ namespace ConvenientInventory
         /// </summary>
         public static void DrawFavoriteItemSlotHighlightsInToolbar(SpriteBatch spriteBatch, int yPositionOnScreen, float transparency, string[] slotText)
         {
-            for (int i = 0; i < NumberOfToolbarItems; i++)
+            var numberToolbarItems = Math.Min(12, Game1.player.MaxItems);
+            for (var i = 0; i < numberToolbarItems; i++)
             {
                 if (!FavoriteItemSlots[i])
                 {
@@ -1147,7 +1150,5 @@ namespace ConvenientInventory
         {
             TransferredItemSprites.Add(itemSprite);
         }
-
-        private static int NumberOfToolbarItems => Math.Min(12, Game1.player.MaxItems);
     }
 }

--- a/ConvenientInventory/ConvenientInventory.cs
+++ b/ConvenientInventory/ConvenientInventory.cs
@@ -612,9 +612,9 @@ namespace ConvenientInventory
                 return true;
             }
 
-            if (clickPos >= 12)
+            if (clickPos >= NumberOfToolbarItems)
             {
-                for (int k = 0; k < 12; k++)
+                for (int k = 0; k < NumberOfToolbarItems; k++)
                 {
                     if (Game1.player.Items[k] == null || Game1.player.Items[k].canStackWith(item))
                     {
@@ -624,9 +624,9 @@ namespace ConvenientInventory
                     }
                 }
             }
-            else if (clickPos < 12)
+            else
             {
-                for (int j = 12; j < Game1.player.Items.Count; j++)
+                for (int j = NumberOfToolbarItems; j < Game1.player.Items.Count; j++)
                 {
                     if (Game1.player.Items[j] == null || Game1.player.Items[j].canStackWith(item))
                     {
@@ -699,7 +699,7 @@ namespace ConvenientInventory
         /// </summary>
         public static void ShiftToolbar(bool right)
         {
-            RotateArray(FavoriteItemSlots, 12, right);
+            RotateArray(FavoriteItemSlots, NumberOfToolbarItems, right);
         }
 
         private static void RotateArray(bool[] arr, int count, bool right)
@@ -973,7 +973,7 @@ namespace ConvenientInventory
         /// </summary>
         public static void DrawFavoriteItemSlotHighlightsInToolbar(SpriteBatch spriteBatch, int yPositionOnScreen, float transparency, string[] slotText)
         {
-            for (int i = 0; i < 12; i++)
+            for (int i = 0; i < NumberOfToolbarItems; i++)
             {
                 if (!FavoriteItemSlots[i])
                 {
@@ -1147,5 +1147,7 @@ namespace ConvenientInventory
         {
             TransferredItemSprites.Add(itemSprite);
         }
+
+        private static int NumberOfToolbarItems => Math.Min(12, Game1.player.MaxItems);
     }
 }


### PR DESCRIPTION
This is an attempt at fixing https://github.com/alanperrow/StardewModding/issues/40

Please consider that I am not particularly familiar with this mod. I made this fix to try to help my Archipelago players, many of whom are big fans of Convenient Inventory. I would like to not have to tell them that our mods are incompatible.

As a result, I am not very knowledgeable about the potential side effects of my fixes. Please tell me if you need me to make more changes, or do some changes differently.

